### PR TITLE
Add inference support to the backend

### DIFF
--- a/src/openvino.cc
+++ b/src/openvino.cc
@@ -139,7 +139,8 @@ ModelState::ReadNetwork(
             "' for model instance '" + Name() + "'");
   }
 
-  *network = inference_core_.ReadNetwork(*model_path);
+  RETURN_IF_OPENVINO_ASSIGN_ERROR(
+      *network, inference_core_.ReadNetwork(*model_path), "reading network");
 
   return nullptr;  // success
 }
@@ -150,8 +151,10 @@ ModelState::LoadNetwork(
     const std::map<std::string, std::string> network_config,
     InferenceEngine::ExecutableNetwork* executable_network)
 {
-  *executable_network =
-      inference_core_.LoadNetwork(network, device, network_config);
+  RETURN_IF_OPENVINO_ASSIGN_ERROR(
+      *executable_network,
+      inference_core_.LoadNetwork(network, device, network_config),
+      "loading network");
 
   return nullptr;  // success
 }
@@ -186,11 +189,9 @@ class ModelInstanceState : public BackendModelInstance {
   // Get the state of the model that corresponds to this instance.
   ModelState* StateForModel() const { return model_state_; }
 
-#if 0
   // Execute...
   void ProcessRequests(
       TRITONBACKEND_Request** requests, const uint32_t request_count);
-#endif
 
  private:
   ModelInstanceState(
@@ -200,12 +201,12 @@ class ModelInstanceState : public BackendModelInstance {
   TRITONSERVER_Error* ValidateConfigureNetwork();
   TRITONSERVER_Error* ValidateInputs(const size_t expected_input_cnt);
   TRITONSERVER_Error* ValidateOutputs();
-#if 0
-  void OrtRun(
+
+  TRITONSERVER_Error* CreateInferRequest();
+  TRITONSERVER_Error* SetBatch(const int batch_size);
+  TRITONSERVER_Error* Infer(
       std::vector<TRITONBACKEND_Response*>* responses,
-      const uint32_t response_count,
-      const std::vector<const char*>& input_names,
-      const std::vector<const char*>& output_names);
+      const uint32_t response_count);
   void SetInputTensors(
       size_t total_batch_size, TRITONBACKEND_Request** requests,
       const uint32_t request_count,
@@ -216,7 +217,6 @@ class ModelInstanceState : public BackendModelInstance {
       size_t total_batch_size, const std::vector<const char*>& output_names,
       TRITONBACKEND_Request** requests, const uint32_t request_count,
       std::vector<TRITONBACKEND_Response*>* responses);
-#endif
 
   ModelState* model_state_;
 
@@ -263,7 +263,6 @@ ModelInstanceState::ModelInstanceState(
 
   THROW_IF_BACKEND_INSTANCE_ERROR(
       model_state_->ReadNetwork(ArtifactFilename(), &model_path_, &network_));
-
   THROW_IF_BACKEND_INSTANCE_ERROR(ValidateConfigureNetwork());
 
   // enable dynamic batching in the network
@@ -276,7 +275,17 @@ ModelInstanceState::ModelInstanceState(
   THROW_IF_BACKEND_INSTANCE_ERROR(model_state->LoadNetwork(
       network_, device_, network_config, &executable_network_));
 
-  infer_request_ = executable_network_.CreateInferRequest();
+  THROW_IF_BACKEND_INSTANCE_ERROR(CreateInferRequest());
+}
+
+TRITONSERVER_Error*
+ModelInstanceState::CreateInferRequest()
+{
+  RETURN_IF_OPENVINO_ASSIGN_ERROR(
+      infer_request_, executable_network_.CreateInferRequest(),
+      "creating infer request object");
+
+  return nullptr;
 }
 
 TRITONSERVER_Error*
@@ -337,7 +346,9 @@ ModelInstanceState::ValidateInputs(const size_t expected_input_cnt)
            io_name + "' for model '" + model_state_->Name() + "'")
               .c_str());
     }
-    iit->second->setPrecision(openvino_precision);
+    RETURN_IF_OPENVINO_ERROR(
+        iit->second->setPrecision(openvino_precision),
+        std::string("setting precision for " + io_name).c_str());
 
     // If a reshape is provided for the input then use that when
     // validating that the model matches what is expected.
@@ -354,8 +365,9 @@ ModelInstanceState::ValidateInputs(const size_t expected_input_cnt)
   }
 
   // Configuring the network to handle the max_batch_size
-  SetBatchSize(model_state_->MaxBatchSize(), &network_);
-
+  RETURN_IF_OPENVINO_ERROR(
+      SetBatchSize(model_state_->MaxBatchSize(), &network_),
+      "setting max batch size");
   return nullptr;  // success
 }
 
@@ -392,7 +404,9 @@ ModelInstanceState::ValidateOutputs()
            io_name + "' for model '" + model_state_->Name() + "'")
               .c_str());
     }
-    iit->second->setPrecision(openvino_precision);
+    RETURN_IF_OPENVINO_ERROR(
+        iit->second->setPrecision(openvino_precision),
+        std::string("setting precision for " + io_name).c_str());
 
     // If a reshape is provided for the input then use that when
     // validating that the model matches what is expected.
@@ -411,7 +425,6 @@ ModelInstanceState::ValidateOutputs()
   return nullptr;  // success
 }
 
-#if 0
 void
 ModelInstanceState::ProcessRequests(
     TRITONBACKEND_Request** requests, const uint32_t request_count)
@@ -515,19 +528,6 @@ ModelInstanceState::ProcessRequests(
     }
   }
 
-  // Use scoped class to clean up ORT tensors and other resources that
-  // need to persist until ORT run completes.
-  struct ScopedCleanup {
-    ScopedCleanup(ModelInstanceState* ctx) : ctx_(ctx) {}
-    ~ScopedCleanup()
-    {
-      if (ctx_ != nullptr) {
-        ctx_->ReleaseOrtRunResources();
-      }
-    }
-    ModelInstanceState* ctx_;
-  } io_tensor_wrapper(this);
-
   std::vector<const char*> input_names;
   bool cuda_copy = false;
   BackendInputCollector collector(
@@ -537,10 +537,7 @@ ModelInstanceState::ProcessRequests(
       total_batch_size, requests, request_count, &responses, &collector,
       &input_names, &cuda_copy);
 
-  // Request to retrieve all model outputs. 'output_names' and
-  // 'output_tensors_' are parallel vectors and so must be kept in
-  // sync. [TODO] should collect only the outputs needed by some
-  // request.
+  // Request to retrieve all model outputs.
   std::vector<const char*> output_names;
   {
     triton::common::TritonJson::Value ios;
@@ -564,21 +561,22 @@ ModelInstanceState::ProcessRequests(
         }
 
         output_names.emplace_back(io_name);
-        output_tensors_.emplace_back(nullptr);
       }
-    }
-
-    if (err != nullptr) {
-      SendErrorForResponses(&responses, request_count, err);
-      output_names.clear();
     }
   }
 
   uint64_t compute_start_ns = 0;
   SET_TIMESTAMP(compute_start_ns);
 
+  // Sets the new batch size before issuing the inference.
+  if (max_batch_size != 0) {
+    RESPOND_ALL_AND_RETURN_IF_ERROR(
+        &responses, request_count, SetBatch(total_batch_size));
+  }
+
   // Run...
-  OrtRun(&responses, request_count, input_names, output_names);
+  RESPOND_ALL_AND_RETURN_IF_ERROR(
+      &responses, request_count, Infer(&responses, request_count));
 
   uint64_t compute_end_ns = 0;
   SET_TIMESTAMP(compute_end_ns);
@@ -625,28 +623,23 @@ ModelInstanceState::ProcessRequests(
       "failed reporting batch request statistics");
 }
 
-void
-ModelInstanceState::OrtRun(
-    std::vector<TRITONBACKEND_Response*>* responses,
-    const uint32_t response_count, const std::vector<const char*>& input_names,
-    const std::vector<const char*>& output_names)
+TRITONSERVER_Error*
+ModelInstanceState::SetBatch(const int batch_size)
 {
-  OrtStatus* status = ort_api->Run(
-      session_, NULL /* run options */, input_names.data(),
-      (const OrtValue* const*)input_tensors_.data(), input_tensors_.size(),
-      output_names.data(), output_names.size(), output_tensors_.data());
+  RETURN_IF_OPENVINO_ERROR(
+      infer_request_.SetBatch(batch_size), "setting batch size");
 
-  if (status != nullptr) {
-    OrtErrorCode code = ort_api->GetErrorCode(status);
-    std::string msg = ort_api->GetErrorMessage(status);
-    SendErrorForResponses(
-        responses, response_count,
-        TRITONSERVER_ErrorNew(
-            TRITONSERVER_ERROR_INTERNAL,
-            (std::string("openvino execute failure ") +
-             std::to_string(code) + ": " + msg)
-                .c_str()));
-  }
+  return nullptr;
+}
+
+TRITONSERVER_Error*
+ModelInstanceState::Infer(
+    std::vector<TRITONBACKEND_Response*>* responses,
+    const uint32_t response_count)
+{
+  RETURN_IF_OPENVINO_ERROR(infer_request_.Infer(), "running inference");
+
+  return nullptr;
 }
 
 void
@@ -665,6 +658,9 @@ ModelInstanceState::SetInputTensors(
   RESPOND_ALL_AND_RETURN_IF_ERROR(
       responses, request_count,
       TRITONBACKEND_RequestInputCount(requests[0], &input_count));
+
+  auto input_tensor_infos{network_.getInputsInfo()};
+
   for (uint32_t input_idx = 0; input_idx < input_count; input_idx++) {
     TRITONBACKEND_Input* input;
     RESPOND_ALL_AND_RETURN_IF_ERROR(
@@ -682,7 +678,6 @@ ModelInstanceState::SetInputTensors(
             &input_dims_count, nullptr, nullptr));
 
     input_names->emplace_back(input_name);
-    input_tensors_.emplace_back(nullptr);
 
     // The shape for the entire input patch, [total_batch_size, ...]
     std::vector<int64_t> batchn_shape(
@@ -691,275 +686,34 @@ ModelInstanceState::SetInputTensors(
       batchn_shape[0] = total_batch_size;
     }
 
-    // [TODO] currently ONNX Runtime only recognize input data on CPU
-    // https://github.com/microsoft/onnxruntime/issues/1621
-    if (input_datatype != TRITONSERVER_TYPE_BYTES) {
-      // The input must be in contiguous CPU memory. Use a pinned
-      // memory if possible for the case where the inputs are being
-      // provided in GPU memory.
-      //
-      // [TODO] a couple of optimizations are possible here. 1) if we
-      // know that all data for this input across all requests was not
-      // in GPU memory, then we could just use regular CPU memory and
-      // not pinned memory. 2) if there is a single request and for
-      // this input the data is already in contiguous CPU memory then
-      // we don't need to copy at all.
-      const int64_t batchn_byte_size =
-          GetByteSize(input_datatype, batchn_shape);
+    const int64_t batchn_byte_size = GetByteSize(input_datatype, batchn_shape);
 
-      BackendMemory* input_memory;
-      RESPOND_ALL_AND_RETURN_IF_ERROR(
-          responses, request_count,
-          BackendMemory::Create(
-              model_state_->TritonMemoryManager(),
-              {BackendMemory::AllocationType::CPU_PINNED_POOL,
-               BackendMemory::AllocationType::CPU},
-              0 /* memory_type_id */, batchn_byte_size, &input_memory));
-      input_tensor_memories_.push_back(input_memory);
+    BackendMemory* input_memory;
+    RESPOND_ALL_AND_RETURN_IF_ERROR(
+        responses, request_count,
+        BackendMemory::Create(
+            model_state_->TritonMemoryManager(),
+            {BackendMemory::AllocationType::CPU_PINNED_POOL,
+             BackendMemory::AllocationType::CPU},
+            0 /* memory_type_id */, batchn_byte_size, &input_memory));
 
-      TRITONSERVER_MemoryType input_memtype = input_memory->MemoryType();
-      char* input_buffer = input_memory->MemoryPtr();
+    TRITONSERVER_MemoryType input_memtype = input_memory->MemoryType();
+    char* input_buffer = input_memory->MemoryPtr();
 
-      // Create ORT Tensor
-      const OrtMemoryInfo* allocator_info;
-      RESPOND_ALL_AND_RETURN_IF_ORT_ERROR(
-          responses, request_count,
-          ort_api->AllocatorGetInfo(allocator_, &allocator_info));
-      RESPOND_ALL_AND_RETURN_IF_ORT_ERROR(
-          responses, request_count,
-          ort_api->CreateTensorWithDataAsOrtValue(
-              allocator_info, (void*)input_buffer, batchn_byte_size,
-              batchn_shape.data(), batchn_shape.size(),
-              ConvertToOnnxDataType(input_datatype), &input_tensors_.back()));
+    // Set the input blob to the buffer without allocating any new memory
+    InferenceEngine::Blob::Ptr data_blob{WrapInputBufferToBlob(
+        input_tensor_infos[input_name]->getTensorDesc(), input_buffer)};
 
-      collector->ProcessTensor(
-          input_name, input_buffer, batchn_byte_size, input_memtype, 0);
-    } else {
-      // For BYTES input, we need to convert the serialized string
-      // representation into what is required for ORT. ORT expects a
-      // vector of char*, one for each element. For each tensor we get
-      // a copy of the data in a contiguous CPU buffer and then
-      // in-place modify that from the Triton
-      // <int32_len><bytes><int32_len><bytes>... serialization into a
-      // <bytes><null-terminator><bytes><null-terminator>... serialization
-      // and then initialize 'string_ptrs' to point to each <bytes>.
-      std::vector<const char*> string_ptrs;
+    RESPOND_ALL_AND_RETURN_IF_OPENVINO_ERROR(
+        responses, request_count, infer_request_.SetBlob(input_name, data_blob),
+        "setting the input tensor data");
 
-      SetStringInputTensor(
-          requests, request_count, responses, input_name, &string_ptrs,
-          cuda_copy);
-
-      RESPOND_ALL_AND_RETURN_IF_ORT_ERROR(
-          responses, request_count,
-          ort_api->CreateTensorAsOrtValue(
-              allocator_, batchn_shape.data(), batchn_shape.size(),
-              ONNX_TENSOR_ELEMENT_DATA_TYPE_STRING, &input_tensors_.back()));
-      RESPOND_ALL_AND_RETURN_IF_ORT_ERROR(
-          responses, request_count,
-          ort_api->FillStringTensor(
-              input_tensors_.back(), string_ptrs.data(), string_ptrs.size()));
-    }
+    collector->ProcessTensor(
+        input_name, input_buffer, batchn_byte_size, input_memtype, 0);
   }
 
   // Finalize...
   *cuda_copy |= collector->Finalize();
-}
-
-void
-ModelInstanceState::SetStringInputTensor(
-    TRITONBACKEND_Request** requests, const uint32_t request_count,
-    std::vector<TRITONBACKEND_Response*>* responses, const char* input_name,
-    std::vector<const char*>* string_ptrs, bool* cuda_copy)
-{
-  size_t total_byte_size = 0;
-  std::vector<size_t> expected_byte_sizes;
-  std::vector<size_t> expected_element_cnts;
-  expected_byte_sizes.reserve(request_count);
-  expected_element_cnts.reserve(request_count);
-  for (size_t ridx = 0; ridx < request_count; ++ridx) {
-    TRITONBACKEND_Input* in;
-    RESPOND_AND_SET_NULL_IF_ERROR(
-        &((*responses)[ridx]),
-        TRITONBACKEND_RequestInput(requests[ridx], input_name, &in));
-
-    const int64_t* input_shape;
-    uint32_t input_dims_count;
-    uint64_t input_byte_size;
-    RESPOND_ALL_AND_RETURN_IF_ERROR(
-        responses, request_count,
-        TRITONBACKEND_InputProperties(
-            in, nullptr, nullptr, &input_shape, &input_dims_count,
-            &input_byte_size, nullptr));
-
-    // Skip input in this request if error response has already been sent.
-    if ((*responses)[ridx] == nullptr) {
-      expected_byte_sizes.push_back(0);
-      expected_element_cnts.push_back(0);
-    } else {
-      expected_element_cnts.push_back(
-          GetElementCount(input_shape, input_dims_count));
-      expected_byte_sizes.push_back(input_byte_size);
-    }
-
-    total_byte_size += expected_byte_sizes.back();
-  }
-
-  // For string input, the copy to contiguous buffer is needed because ORT
-  // expects elements to be C strings thus we need to modify input buffer.
-  // Reserve one more byte at the end of input_buffer to ensure last
-  // element of String data can become valid C string.
-  BackendMemory* input_memory;
-  RESPOND_ALL_AND_RETURN_IF_ERROR(
-      responses, request_count,
-      BackendMemory::Create(
-          model_state_->TritonMemoryManager(),
-          {BackendMemory::AllocationType::CPU_PINNED_POOL,
-           BackendMemory::AllocationType::CPU},
-          0 /* memory_type_id */, total_byte_size + 1, &input_memory));
-  input_tensor_memories_.push_back(input_memory);
-
-  const TRITONSERVER_MemoryType mem_type = input_memory->MemoryType();
-  char* input_buffer = input_memory->MemoryPtr();
-
-  size_t buffer_offset = 0;
-  for (size_t ridx = 0; ridx < request_count; ++ridx) {
-    TRITONBACKEND_Input* in;
-    TRITONSERVER_Error* err =
-        TRITONBACKEND_RequestInput(requests[ridx], input_name, &in);
-    if ((err == nullptr) && ((*responses)[ridx] != nullptr)) {
-      uint32_t input_buffer_count;
-      RESPOND_ALL_AND_RETURN_IF_ERROR(
-          responses, request_count,
-          TRITONBACKEND_InputProperties(
-              in, nullptr, nullptr, nullptr, nullptr, nullptr,
-              &input_buffer_count));
-
-      size_t input_offset = 0;
-      for (size_t idx = 0; idx < input_buffer_count; ++idx) {
-        const void* src_buffer;
-        size_t src_byte_size;
-        TRITONSERVER_MemoryType src_memory_type;
-        int64_t src_memory_type_id;
-        err = TRITONBACKEND_InputBuffer(
-            in, idx, &src_buffer, &src_byte_size, &src_memory_type,
-            &src_memory_type_id);
-        if (err == nullptr) {
-          if ((input_offset + src_byte_size) > expected_byte_sizes[ridx]) {
-            err = TRITONSERVER_ErrorNew(
-                TRITONSERVER_ERROR_INVALID_ARG,
-                (std::string("buffer size for input '") + input_name +
-                 "' exceeds batch byte size " +
-                 std::to_string(expected_byte_sizes[ridx]))
-                    .c_str());
-          } else {
-            bool cuda_used = false;
-            err = CopyBuffer(
-                input_name, src_memory_type, src_memory_type_id, mem_type, 0,
-                src_byte_size, src_buffer,
-                input_buffer + buffer_offset + input_offset, CudaStream(),
-                &cuda_used);
-            *cuda_copy |= cuda_used;
-          }
-        }
-
-        if (err == nullptr) {
-          input_offset += src_byte_size;
-        } else {
-          break;
-        }
-      }
-    }
-
-    if (err != nullptr) {
-      if ((*responses)[ridx] != nullptr) {
-        RESPOND_AND_SET_NULL_IF_ERROR(&((*responses)[ridx]), err);
-      }
-
-      TRITONSERVER_ErrorDelete(err);
-    }
-
-    buffer_offset += expected_byte_sizes[ridx];
-  }
-
-  // Modify input buffer and set string expected by ORT
-  SetStringInputBuffer(
-      input_name, expected_byte_sizes, expected_element_cnts, responses,
-      input_buffer, string_ptrs);
-  input_buffer[total_byte_size] = 0;
-}
-
-void
-ModelInstanceState::SetStringInputBuffer(
-    const std::string& input_name,
-    const std::vector<size_t>& expected_byte_sizes,
-    const std::vector<size_t>& expected_element_cnts,
-    std::vector<TRITONBACKEND_Response*>* responses, char* input_buffer,
-    std::vector<const char*>* string_ptrs)
-{
-  // offset for each response
-  size_t buffer_copy_offset = 0;
-  for (size_t idx = 0; idx < expected_byte_sizes.size(); idx++) {
-    const size_t expected_byte_size = expected_byte_sizes[idx];
-    const size_t expected_element_cnt = expected_element_cnts[idx];
-
-    size_t element_cnt = 0;
-    if ((*responses)[idx] != nullptr) {
-      size_t remaining_bytes = expected_byte_size;
-      char* data_content = input_buffer + buffer_copy_offset;
-      // Continue if the remaining bytes may still contain size info
-      while (remaining_bytes >= sizeof(uint32_t)) {
-        if (element_cnt >= expected_element_cnt) {
-          RESPOND_AND_SET_NULL_IF_ERROR(
-              &((*responses)[idx]),
-              TRITONSERVER_ErrorNew(
-                  TRITONSERVER_ERROR_INVALID_ARG,
-                  (std::string("unexpected number of string elements ") +
-                   std::to_string(element_cnt + 1) + " for inference input '" +
-                   input_name + "', expecting " +
-                   std::to_string(expected_element_cnt))
-                      .c_str()));
-          break;
-        }
-
-        const uint32_t len = *(reinterpret_cast<const uint32_t*>(data_content));
-        remaining_bytes -= sizeof(uint32_t);
-        // Make first byte of size info 0, so that if there is string data
-        // in front of it, the data becomes valid C string.
-        *data_content = 0;
-        data_content = data_content + sizeof(uint32_t);
-        if (len > remaining_bytes) {
-          RESPOND_AND_SET_NULL_IF_ERROR(
-              &((*responses)[idx]),
-              TRITONSERVER_ErrorNew(
-                  TRITONSERVER_ERROR_INVALID_ARG,
-                  (std::string("incomplete string data for inference input '") +
-                   input_name + "', expecting string of length " +
-                   std::to_string(len) + " but only " +
-                   std::to_string(remaining_bytes) + " bytes available")
-                      .c_str()));
-          break;
-        } else {
-          string_ptrs->push_back(data_content);
-          element_cnt++;
-          data_content = data_content + len;
-          remaining_bytes -= len;
-        }
-      }
-    }
-
-    FillStringData(string_ptrs, expected_element_cnt - element_cnt);
-    buffer_copy_offset += expected_byte_size;
-  }
-}
-
-void
-ModelInstanceState::FillStringData(
-    std::vector<const char*>* string_ptrs, size_t cnt)
-{
-  static const char* empty = "";
-  for (size_t c = 0; c < cnt; c++) {
-    string_ptrs->push_back(empty);
-  }
 }
 
 void
@@ -973,206 +727,28 @@ ModelInstanceState::ReadOutputTensors(
       model_state_->TritonMemoryManager(), model_state_->EnablePinnedInput(),
       CudaStream());
 
-  // Use to hold string output contents
   bool cuda_copy = false;
-  std::vector<std::vector<char>> string_buffers;
   for (size_t idx = 0; idx < output_names.size(); idx++) {
     std::string name = output_names[idx];
 
-    OrtValue* output_tensor = output_tensors_[idx];
-    if (output_tensor == nullptr) {
-      RESPOND_ALL_AND_RETURN_IF_ERROR(
-          responses, request_count,
-          TRITONSERVER_ErrorNew(
-              TRITONSERVER_ERROR_INTERNAL,
-              (std::string("output tensor '") + name + "' is not found")
-                  .c_str()));
-    }
+    InferenceEngine::Blob::Ptr output_blob;
+    RESPOND_ALL_AND_RETURN_IF_OPENVINO_ASSIGN_ERROR(
+        output_blob, responses, request_count, infer_request_.GetBlob(name),
+        "reading output tensor blob ");
+    auto output_shape =
+        ConvertToSignedShape(output_blob->getTensorDesc().getDims());
 
-    // Get output type and shape
-    OrtTypeInfo* typeinfo;
-    RESPOND_ALL_AND_RETURN_IF_ORT_ERROR(
-        responses, request_count,
-        ort_api->GetTypeInfo(output_tensor, &typeinfo));
-    std::unique_ptr<OrtTypeInfo, TypeInfoDeleter> typeinfo_wrapper(typeinfo);
-
-    const OrtTensorTypeAndShapeInfo* type_and_shape;
-    RESPOND_ALL_AND_RETURN_IF_ORT_ERROR(
-        responses, request_count,
-        ort_api->CastTypeInfoToTensorInfo(typeinfo, &type_and_shape));
-
-    size_t num_dims;
-    RESPOND_ALL_AND_RETURN_IF_ORT_ERROR(
-        responses, request_count,
-        ort_api->GetDimensionsCount(type_and_shape, &num_dims));
-
-    std::vector<int64_t> batchn_shape(num_dims);
-    RESPOND_ALL_AND_RETURN_IF_ORT_ERROR(
-        responses, request_count,
-        ort_api->GetDimensions(
-            type_and_shape, batchn_shape.data(), batchn_shape.size()));
-
-    ONNXTensorElementDataType type;
-    RESPOND_ALL_AND_RETURN_IF_ORT_ERROR(
-        responses, request_count,
-        ort_api->GetTensorElementType(type_and_shape, &type));
-
-    if (type == ONNX_TENSOR_ELEMENT_DATA_TYPE_STRING) {
-      const size_t element_count = GetElementCount(batchn_shape);
-      size_t total_length = 0;
-      RESPOND_ALL_AND_RETURN_IF_ORT_ERROR(
-          responses, request_count,
-          ort_api->GetStringTensorDataLength(output_tensor, &total_length));
-
-      string_buffers.emplace_back(std::vector<char>(total_length));
-      auto content = string_buffers.back().data();
-      std::vector<size_t> offsets(element_count + 1);
-      RESPOND_ALL_AND_RETURN_IF_ORT_ERROR(
-          responses, request_count,
-          ort_api->GetStringTensorContent(
-              output_tensor, content, total_length, offsets.data(),
-              element_count));
-      // Mark "passed end byte offset"
-      offsets[element_count] = total_length;
-
-      cuda_copy |= SetStringOutputBuffer(
-          name, content, offsets.data(), &batchn_shape, requests, request_count,
-          responses);
-    } else {
-      // Fixed size data type...
-      char* output_buffer = nullptr;
-      RESPOND_ALL_AND_RETURN_IF_ORT_ERROR(
-          responses, request_count,
-          ort_api->GetTensorMutableData(output_tensor, (void**)&output_buffer));
-
-      // [TODO] currently ONNX output data are always on CPU
-      // https://github.com/microsoft/onnxruntime/issues/1621
-      responder.ProcessTensor(
-          name, ConvertFromOnnxDataType(type), batchn_shape, output_buffer,
-          TRITONSERVER_MEMORY_CPU, 0);
-    }
+    auto const mem_locker = output_blob->cbuffer();
+    responder.ProcessTensor(
+        name,
+        ConvertFromOpenVINOPrecision(
+            output_blob->getTensorDesc().getPrecision()),
+        output_shape, mem_locker.as<const char*>(), TRITONSERVER_MEMORY_CPU, 0);
   }
 
   // Finalize and wait for any pending buffer copies.
   cuda_copy |= responder.Finalize();
-
 }
-
-bool
-ModelInstanceState::SetStringOutputBuffer(
-    const std::string& name, const char* content, const size_t* offsets,
-    std::vector<int64_t>* batchn_shape, TRITONBACKEND_Request** requests,
-    const uint32_t request_count,
-    std::vector<TRITONBACKEND_Response*>* responses)
-{
-  size_t element_idx = 0;
-  bool cuda_copy = false;
-  for (size_t ridx = 0; ridx < request_count; ++ridx) {
-    const auto& request = requests[ridx];
-    auto& response = (*responses)[ridx];
-
-    // batchn_shape holds the shape of the entire tensor batch. When
-    // batching is enabled override the first batch dimension with each
-    // requests batch size (reusing for efficiency).
-    if (model_state_->MaxBatchSize() > 0) {
-      TRITONBACKEND_Input* input;
-      TRITONBACKEND_RequestInputByIndex(request, 0 /* index */, &input);
-      const int64_t* shape;
-      TRITONBACKEND_InputProperties(
-          input, nullptr, nullptr, &shape, nullptr, nullptr, nullptr);
-      (*batchn_shape)[0] = shape[0];
-    }
-
-    const size_t expected_element_cnt = GetElementCount(*batchn_shape);
-
-    // If 'request' requested this output then copy it from
-    // 'content'. If it did not request this output then just skip it
-    // in the 'content'.
-    bool need_output = false;
-    if (response != nullptr) {
-      uint32_t output_count;
-      RESPOND_AND_SET_NULL_IF_ERROR(
-          &response, TRITONBACKEND_RequestOutputCount(request, &output_count));
-      if (response != nullptr) {
-        for (uint32_t output_idx = 0; output_idx < output_count; output_idx++) {
-          const char* req_output_name;
-          RESPOND_AND_SET_NULL_IF_ERROR(
-              &response, TRITONBACKEND_RequestOutputName(
-                             request, output_idx, &req_output_name));
-          if ((response != nullptr) && (req_output_name == name)) {
-            need_output = true;
-            break;
-          }
-        }
-      }
-    }
-
-    if (need_output) {
-      TRITONBACKEND_Output* response_output;
-      TRITONSERVER_Error* err = TRITONBACKEND_ResponseOutput(
-          response, &response_output, name.c_str(), TRITONSERVER_TYPE_BYTES,
-          batchn_shape->data(), batchn_shape->size());
-      if (err == nullptr) {
-        // Calculate expected byte size in advance using string offsets
-        const size_t data_byte_size =
-            offsets[element_idx + expected_element_cnt] - offsets[element_idx];
-        const size_t expected_byte_size =
-            data_byte_size + sizeof(uint32_t) * expected_element_cnt;
-
-        TRITONSERVER_MemoryType actual_memory_type =
-            TRITONSERVER_MEMORY_CPU_PINNED;
-        int64_t actual_memory_type_id = 0;
-        void* buffer;
-        err = TRITONBACKEND_OutputBuffer(
-            response_output, &buffer, expected_byte_size, &actual_memory_type,
-            &actual_memory_type_id);
-        if (err == nullptr) {
-          bool cuda_used = false;
-          size_t copied_byte_size = 0;
-          for (size_t e = 0; e < expected_element_cnt; ++e) {
-            const uint32_t len =
-                offsets[element_idx + e + 1] - offsets[element_idx + e];
-            // Prepend size of the string
-            err = CopyBuffer(
-                name, TRITONSERVER_MEMORY_CPU /* src_memory_type */,
-                0 /* src_memory_type_id */, actual_memory_type,
-                actual_memory_type_id, sizeof(uint32_t),
-                static_cast<const void*>(&len),
-                static_cast<char*>(buffer) + copied_byte_size, stream_,
-                &cuda_used);
-            if (err != nullptr) {
-              break;
-            }
-
-            cuda_copy |= cuda_used;
-            copied_byte_size += sizeof(uint32_t);
-
-            // Copy raw string content
-            err = CopyBuffer(
-                name, TRITONSERVER_MEMORY_CPU /* src_memory_type */,
-                0 /* src_memory_type_id */, actual_memory_type,
-                actual_memory_type_id, len, content + offsets[element_idx + e],
-                static_cast<char*>(buffer) + copied_byte_size, stream_,
-                &cuda_used);
-            if (err != nullptr) {
-              break;
-            }
-
-            cuda_copy |= cuda_used;
-            copied_byte_size += len;
-          }
-        }
-      }
-
-      RESPOND_AND_SET_NULL_IF_ERROR(&response, err);
-    }
-
-    element_idx += expected_element_cnt;
-  }
-
-  return cuda_copy;
-}
-#endif
 
 /////////////
 
@@ -1361,7 +937,7 @@ TRITONBACKEND_ModelInstanceExecute(
   // this function. If something does go wrong in processing a
   // particular request then we send an error response just for the
   // specific request.
-  //  instance_state->ProcessRequests(requests, request_count);
+  instance_state->ProcessRequests(requests, request_count);
 
   return nullptr;  // success
 }


### PR DESCRIPTION
I was able to resolve the issues and run perf_analyzer on the models. 

```
# ./qa/clients/perf_analyzer -m  resnet50_fp16_openvino
*** Measurement Settings ***
  Batch size: 1
  Measurement window: 5000 msec
  Using synchronous calls for inference
  Stabilizing using average latency

Request concurrency: 1
  Client: 
    Request count: 378
    Throughput: 75.6 infer/sec
    Avg latency: 13220 usec (standard deviation 1531 usec)
    p50 latency: 12491 usec
    p90 latency: 14745 usec
    p95 latency: 16421 usec
    p99 latency: 18464 usec
    Avg HTTP time: 13191 usec (send/recv 141 usec + response wait 13050 usec)
  Server: 
    Inference count: 455
    Execution count: 455
    Successful request count: 455
    Avg request latency: 12285 usec (overhead 56 usec + queue 26 usec + compute input 370 usec + compute infer 11761 usec + compute output 72 usec)

Inferences/Second vs. Client Average Batch Latency
Concurrency: 1, throughput: 75.6 infer/sec, latency 13220 usec
```
