### PR TITLE
Exposing plugin configuration through model_config parameters

### DIFF
--- a/src/openvino_utils.cc
+++ b/src/openvino_utils.cc
@@ -31,6 +31,17 @@
 namespace triton { namespace backend { namespace openvino {
 
 std::string
+ConvertVersionMapToString(
+    const std::map<std::string, InferenceEngine::Version>& version_map)
+{
+  std::string result;
+  for (const auto& it : version_map) {
+    result += (it.first) + ":" + (it.second.description) + "\n ";
+  }
+  return result;
+}
+
+std::string
 OpenVINOPrecisionToString(InferenceEngine::Precision openvino_precision)
 {
   switch (openvino_precision) {
@@ -313,6 +324,18 @@ CompareDimsSupported(
   return nullptr;  // success
 }
 
+TRITONSERVER_Error*
+ReadParameter(
+    triton::common::TritonJson::Value& params, const std::string& key,
+    std::string* param)
+{
+  triton::common::TritonJson::Value value;
+  RETURN_ERROR_IF_FALSE(
+      params.Find(key.c_str(), &value), TRITONSERVER_ERROR_INVALID_ARG,
+      std::string("model configuration is missing the parameter ") + key);
+  RETURN_IF_ERROR(value.MemberAsString("string_value", param));
+  return nullptr;  // success
+}
 
 void
 SetBatchSize(const size_t batch_size, InferenceEngine::CNNNetwork* network)

--- a/src/openvino_utils.h
+++ b/src/openvino_utils.h
@@ -31,6 +31,7 @@
 #include <string>
 #include <unordered_map>
 #include <vector>
+#include "triton/backend/backend_common.h"
 #include "triton/core/tritonserver.h"
 
 namespace triton { namespace backend { namespace openvino {
@@ -131,12 +132,13 @@ namespace triton { namespace backend { namespace openvino {
   } while (false)
 
 
+std::string ConvertVersionMapToString(
+    const std::map<std::string, InferenceEngine::Version>& version_map);
 std::string OpenVINOPrecisionToString(
     InferenceEngine::Precision openvino_precision);
 
 TRITONSERVER_DataType ConvertFromOpenVINOPrecision(
     InferenceEngine::Precision openvino_precision);
-
 InferenceEngine::Precision ConvertToOpenVINOPrecision(
     TRITONSERVER_DataType data_type);
 InferenceEngine::Precision ConvertToOpenVINOPrecision(
@@ -151,6 +153,10 @@ TRITONSERVER_Error* CompareDimsSupported(
     const std::string& model_name, const std::string& tensor_name,
     const std::vector<size_t>& model_shape, const std::vector<int64_t>& dims,
     const int max_batch_size, const bool compare_exact);
+
+TRITONSERVER_Error* ReadParameter(
+    triton::common::TritonJson::Value& params, const std::string& key,
+    std::string* param);
 
 void SetBatchSize(
     const size_t batch_size, InferenceEngine::CNNNetwork* network);


### PR DESCRIPTION
The config operations were selected from [here](https://github.com/openvinotoolkit/openvino/blob/master/inference-engine/samples/benchmark_app/main.cpp#L243).

### With default `CPU_THROUGHPUT_STREAM` settings:
```
./qa/clients/perf_analyzer -m resnet50_fp16_openvino --concurrency-range 14 -v
*** Measurement Settings ***
  Batch size: 1
  Measurement window: 5000 msec
  Using synchronous calls for inference
  Stabilizing using average latency

Request concurrency: 14
  Pass [1] throughput: 81.8 infer/sec. Avg latency: 122316 usec (std 5114 usec)
  Pass [2] throughput: 80.6 infer/sec. Avg latency: 123919 usec (std 7521 usec)
  Pass [3] throughput: 80.8 infer/sec. Avg latency: 123944 usec (std 7223 usec)
  Client: 
    Request count: 404
    Throughput: 80.8 infer/sec
    Avg latency: 123944 usec (standard deviation 7223 usec)
    p50 latency: 121263 usec
    p90 latency: 127987 usec
    p95 latency: 141420 usec
    p99 latency: 157765 usec
    Avg HTTP time: 123965 usec (send 170 usec + response wait 123795 usec + receive 0 usec)
  Server: 
    Inference count: 484
    Execution count: 484
    Successful request count: 484
    Avg request latency: 122705 usec (overhead 91 usec + queue 50 usec + compute input 449 usec + compute infer 122005 usec + compute output 110 usec)

Inferences/Second vs. Client Average Batch Latency
Concurrency: 10, throughput: 80.8 infer/sec, latency 123944 usec
```
### With  `CPU_THROUGHPUT_STREAM` set to default:

```
./qa/clients/perf_analyzer -m resnet50_fp16_openvino --concurrency-range 14 -v
*** Measurement Settings ***
  Batch size: 1
  Measurement window: 5000 msec
  Using synchronous calls for inference
  Stabilizing using average latency

Request concurrency: 14
  Pass [1] throughput: 91.8 infer/sec. Avg latency: 152530 usec (std 9809 usec)
  Pass [2] throughput: 91.2 infer/sec. Avg latency: 154325 usec (std 10212 usec)
  Pass [3] throughput: 91.2 infer/sec. Avg latency: 153254 usec (std 10110 usec)
  Client: 
    Request count: 456
    Throughput: 91.2 infer/sec
    Avg latency: 153254 usec (standard deviation 10110 usec)
    p50 latency: 153848 usec
    p90 latency: 165254 usec
    p95 latency: 169629 usec
    p99 latency: 181234 usec
    Avg HTTP time: 153533 usec (send 212 usec + response wait 153320 usec + receive 1 usec)
  Server: 
    Inference count: 547
    Execution count: 547
    Successful request count: 547
    Avg request latency: 151886 usec (overhead 113 usec + queue 42208 usec + compute input 550 usec + compute infer 108893 usec + compute output 122 usec)

Inferences/Second vs. Client Average Batch Latency
Concurrency: 14, throughput: 91.2 infer/sec, latency 153254 usec
```

There is a `12.5%` improvement in the throughput with specific settings in the # of streams.