### PR TITLE
Provide buffer size while wrapping the blob

### DIFF
--- a/src/openvino.cc
+++ b/src/openvino.cc
@@ -999,15 +999,16 @@ ModelInstanceState::SetInputTensors(
             0 /* memory_type_id */, batchn_byte_size, &input_memory));
 
     TRITONSERVER_MemoryType input_memtype = input_memory->MemoryType();
-    char* input_buffer = input_memory->MemoryPtr();
+    char* input_buffer_ptr = input_memory->MemoryPtr();
 
     collector->ProcessTensor(
-        input_name, input_buffer, batchn_byte_size, input_memtype, 0);
+        input_name, input_buffer_ptr, batchn_byte_size, input_memtype, 0);
 
     if (batch_pad_size_ == 0) {
       // Set the input blob to the buffer without allocating any new memory
       auto data_blob = WrapInputBufferToBlob(
-          input_tensor_infos[input_name]->getTensorDesc(), input_buffer);
+          input_tensor_infos[input_name]->getTensorDesc(), input_buffer_ptr,
+          batchn_byte_size);
       RESPOND_ALL_AND_RETURN_IF_OPENVINO_ERROR(
           responses, request_count,
           infer_request_.SetBlob(input_name, data_blob),
@@ -1026,7 +1027,7 @@ ModelInstanceState::SetInputTensors(
                 .c_str());
       }
       auto dest = (data_blob->buffer()).as<char*>();
-      memcpy(dest, input_buffer, batchn_byte_size);
+      memcpy(dest, input_buffer_ptr, batchn_byte_size);
     }
   }
 

--- a/src/openvino_utils.cc
+++ b/src/openvino_utils.cc
@@ -395,39 +395,50 @@ ConvertToSignedShape(const std::vector<size_t> shape)
 
 InferenceEngine::Blob::Ptr
 WrapInputBufferToBlob(
-    const InferenceEngine::TensorDesc& tensor_desc, char* input_buffer)
+    const InferenceEngine::TensorDesc& tensor_desc, char* input_buffer_ptr,
+    size_t input_buffer_size)
 {
   auto precision{tensor_desc.getPrecision()};
   if (precision == InferenceEngine::Precision::BOOL) {
     return InferenceEngine::make_shared_blob<bool>(
-        tensor_desc, reinterpret_cast<bool*>(input_buffer));
+        tensor_desc, reinterpret_cast<bool*>(input_buffer_ptr),
+        input_buffer_size);
   } else if (precision == InferenceEngine::Precision::U8) {
     return InferenceEngine::make_shared_blob<uint8_t>(
-        tensor_desc, reinterpret_cast<uint8_t*>(input_buffer));
+        tensor_desc, reinterpret_cast<uint8_t*>(input_buffer_ptr),
+        input_buffer_size);
   } else if (precision == InferenceEngine::Precision::U16) {
     return InferenceEngine::make_shared_blob<uint16_t>(
-        tensor_desc, reinterpret_cast<uint16_t*>(input_buffer));
+        tensor_desc, reinterpret_cast<uint16_t*>(input_buffer_ptr),
+        input_buffer_size);
   } else if (precision == InferenceEngine::Precision::U32) {
     return InferenceEngine::make_shared_blob<uint32_t>(
-        tensor_desc, reinterpret_cast<uint32_t*>(input_buffer));
+        tensor_desc, reinterpret_cast<uint32_t*>(input_buffer_ptr),
+        input_buffer_size);
   } else if (precision == InferenceEngine::Precision::U64) {
     return InferenceEngine::make_shared_blob<uint64_t>(
-        tensor_desc, reinterpret_cast<uint64_t*>(input_buffer));
+        tensor_desc, reinterpret_cast<uint64_t*>(input_buffer_ptr),
+        input_buffer_size);
   } else if (precision == InferenceEngine::Precision::I8) {
     return InferenceEngine::make_shared_blob<int8_t>(
-        tensor_desc, reinterpret_cast<int8_t*>(input_buffer));
+        tensor_desc, reinterpret_cast<int8_t*>(input_buffer_ptr),
+        input_buffer_size);
   } else if (precision == InferenceEngine::Precision::I16) {
     return InferenceEngine::make_shared_blob<int16_t>(
-        tensor_desc, reinterpret_cast<int16_t*>(input_buffer));
+        tensor_desc, reinterpret_cast<int16_t*>(input_buffer_ptr),
+        input_buffer_size);
   } else if (precision == InferenceEngine::Precision::I32) {
     return InferenceEngine::make_shared_blob<int32_t>(
-        tensor_desc, reinterpret_cast<int32_t*>(input_buffer));
+        tensor_desc, reinterpret_cast<int32_t*>(input_buffer_ptr),
+        input_buffer_size);
   } else if (precision == InferenceEngine::Precision::I64) {
     return InferenceEngine::make_shared_blob<int64_t>(
-        tensor_desc, reinterpret_cast<int64_t*>(input_buffer));
+        tensor_desc, reinterpret_cast<int64_t*>(input_buffer_ptr),
+        input_buffer_size);
   } else {
     return InferenceEngine::make_shared_blob<float>(
-        tensor_desc, reinterpret_cast<float*>(input_buffer));
+        tensor_desc, reinterpret_cast<float*>(input_buffer_ptr),
+        input_buffer_size);
   }
 }
 

--- a/src/openvino_utils.h
+++ b/src/openvino_utils.h
@@ -167,6 +167,7 @@ bool AdjustShapesBatch(
 std::vector<int64_t> ConvertToSignedShape(const std::vector<size_t> shape);
 
 InferenceEngine::Blob::Ptr WrapInputBufferToBlob(
-    const InferenceEngine::TensorDesc& tensor_desc, char* input_buffer);
+    const InferenceEngine::TensorDesc& tensor_desc, char* input_buffer,
+    size_t input_buffer_size = 0);
 
 }}}  // namespace triton::backend::openvino


### PR DESCRIPTION
Just found `make_shared_blob` has optional parameter to specify the size of the pre-allocated memory as well. I see slight improvement in `compute_input` section using ssd-resnet34 with this change.