### PR TITLE
OpenVINO 2023.0.0

### DIFF
--- a/tools/gen_openvino_dockerfile.py
+++ b/tools/gen_openvino_dockerfile.py
@@ -100,7 +100,6 @@ RUN /bin/bash -c 'cmake \
         -DENABLE_VALIDATION_SET=OFF \
         -DNGRAPH_ONNX_IMPORT_ENABLE=OFF \
         -DNGRAPH_DEPRECATED_ENABLE=FALSE \
-        -DENABLE_OPENCV=OFF \
         -DTREAT_WARNING_AS_ERROR=OFF \
         .. && \
     make -j$(nproc) install'

--- a/tools/gen_openvino_dockerfile.py
+++ b/tools/gen_openvino_dockerfile.py
@@ -184,10 +184,12 @@ RUN xcopy /I /E \\workspace\\install\\runtime\\include\\ngraph include\\ngraph
 RUN xcopy /I /E \\workspace\\install\\runtime\\include\\openvino include\\openvino
 RUN xcopy /I /E \\workspace\\install\\runtime\\bin\\intel64\\%OPENVINO_BUILD_TYPE% bin
 RUN xcopy /I /E \\workspace\\install\\runtime\\lib\\intel64\\%OPENVINO_BUILD_TYPE% lib
-RUN copy \\workspace\\install\\runtime\\3rdparty\\tbb\\bin\\tbb.dll bin\\tbb.dll
-RUN copy \\workspace\\install\\runtime\\3rdparty\\tbb\\bin\\tbb_debug.dll bin\\tbb_debug.dll
+RUN copy \\workspace\\install\\runtime\\3rdparty\\tbb\\bin\\tbb12.dll bin\\tbb12.dll
+RUN copy \\workspace\\install\\runtime\\3rdparty\\tbb\\bin\\tbb12_debug.dll bin\\tbb12_debug.dll
 RUN copy \\workspace\\install\\runtime\\3rdparty\\tbb\\lib\\tbb.lib lib\\tbb.lib
 RUN copy \\workspace\\install\\runtime\\3rdparty\\tbb\\lib\\tbb_debug.lib lib\\tbb_debug.lib
+RUN copy \\workspace\\install\\runtime\\3rdparty\\tbb\\lib\\tbb12.lib lib\\tbb12.lib
+RUN copy \\workspace\\install\\runtime\\3rdparty\\tbb\\lib\\tbb12_debug.lib lib\\tbb12_debug.lib
 '''
 
     with open(FLAGS.output, "w") as dfile:

--- a/tools/gen_openvino_dockerfile.py
+++ b/tools/gen_openvino_dockerfile.py
@@ -100,7 +100,6 @@ RUN /bin/bash -c 'cmake \
         -DENABLE_VALIDATION_SET=OFF \
         -DNGRAPH_ONNX_IMPORT_ENABLE=OFF \
         -DNGRAPH_DEPRECATED_ENABLE=FALSE \
-        -DTREAT_WARNING_AS_ERROR=OFF \
         .. && \
     make -j$(nproc) install'
 

--- a/tools/gen_openvino_dockerfile.py
+++ b/tools/gen_openvino_dockerfile.py
@@ -115,16 +115,14 @@ RUN mkdir -p lib && \
     cp /workspace/install/runtime/lib/intel64/libopenvino_c.so.${OPENVINO_VERSION} lib/. && \
     cp /workspace/install/runtime/lib/intel64/libopenvino_intel_cpu_plugin.so lib/. && \
     cp /workspace/install/runtime/lib/intel64/libopenvino_ir_frontend.so.${OPENVINO_VERSION} lib/.
-RUN OV_SHORT_VERSION=`echo ${OPENVINO_VERSION} | awk '{print substr($0,3,2)}'` && \
-    OV_SHORT_VERSION=${OV_SHORT_VERSION}`echo ${OPENVINO_VERSION} | awk '{print substr($0,6,1)}'` && \
-    OV_SHORT_VERSION=${OV_SHORT_VERSION}`echo ${OPENVINO_VERSION} | awk '{print substr($0,8,1)}'` && \
+RUN OV_SHORT_VERSION=`echo ${OPENVINO_VERSION} | awk '{ split($0,a,"."); print substr(a[1],3) a[2] a[3] }'` && \
     (cd lib && \
         ln -s libopenvino.so.${OPENVINO_VERSION} libopenvino.so.${OV_SHORT_VERSION} && \
-        ln -s libopenvino.so.${OV_SHORT_VERSION} libopenvino.so && \
+        ln -s libopenvino.so.${OPENVINO_VERSION} libopenvino.so && \
         ln -s libopenvino_c.so.${OPENVINO_VERSION} libopenvino_c.so.${OV_SHORT_VERSION} && \
-        ln -s libopenvino_c.so.${OV_SHORT_VERSION} libopenvino_c.so && \
+        ln -s libopenvino_c.so.${OPENVINO_VERSION} libopenvino_c.so && \
         ln -s libopenvino_ir_frontend.so.${OPENVINO_VERSION} libopenvino_ir_frontend.so.${OV_SHORT_VERSION} && \
-        ln -s libopenvino_ir_frontend.so.${OV_SHORT_VERSION} libopenvino_ir_frontend.so)
+        ln -s libopenvino_ir_frontend.so.${OPENVINO_VERSION} libopenvino_ir_frontend.so)
 '''
 
     df += '''

--- a/tools/gen_openvino_dockerfile.py
+++ b/tools/gen_openvino_dockerfile.py
@@ -108,12 +108,23 @@ RUN /bin/bash -c 'cmake \
 WORKDIR /opt/openvino
 RUN cp -r /workspace/openvino/licensing LICENSE.openvino
 RUN mkdir -p include && \
-    cp -r /workspace/install/runtime/include/ie/* include/. && \
     cp -r /workspace/install/runtime/include/ngraph include/. && \
     cp -r /workspace/install/runtime/include/openvino include/.
 RUN mkdir -p lib && \
-    cp /workspace/install/runtime/lib/intel64/*.so lib/. && \
-    cp /workspace/install/runtime/3rdparty/omp/lib/libiomp5.so lib/.
+    cp /workspace/install/runtime/lib/intel64/libopenvino.so.${OPENVINO_VERSION} lib/. && \
+    cp /workspace/install/runtime/lib/intel64/libopenvino_c.so.${OPENVINO_VERSION} lib/. && \
+    cp /workspace/install/runtime/lib/intel64/libopenvino_intel_cpu_plugin.so lib/. && \
+    cp /workspace/install/runtime/lib/intel64/libopenvino_ir_frontend.so.${OPENVINO_VERSION} lib/.
+RUN OV_SHORT_VERSION=`echo ${OPENVINO_VERSION} | awk '{print substr($0,3,2)}'` && \
+    OV_SHORT_VERSION=${OV_SHORT_VERSION}`echo ${OPENVINO_VERSION} | awk '{print substr($0,6,1)}'` && \
+    OV_SHORT_VERSION=${OV_SHORT_VERSION}`echo ${OPENVINO_VERSION} | awk '{print substr($0,8,1)}'` && \
+    (cd lib && \
+        ln -s libopenvino.so.${OPENVINO_VERSION} libopenvino.so.${OV_SHORT_VERSION} && \
+        ln -s libopenvino.so.${OV_SHORT_VERSION} libopenvino.so && \
+        ln -s libopenvino_c.so.${OPENVINO_VERSION} libopenvino_c.so.${OV_SHORT_VERSION} && \
+        ln -s libopenvino_c.so.${OV_SHORT_VERSION} libopenvino_c.so && \
+        ln -s libopenvino_ir_frontend.so.${OPENVINO_VERSION} libopenvino_ir_frontend.so.${OV_SHORT_VERSION} && \
+        ln -s libopenvino_ir_frontend.so.${OV_SHORT_VERSION} libopenvino_ir_frontend.so)
 '''
 
     df += '''


### PR DESCRIPTION
server: https://github.com/triton-inference-server/server/pull/6031
onnxruntime_backend: https://github.com/triton-inference-server/onnxruntime_backend/pull/200

Some notes on the upgrade:
- The `ie` header directory is solely for API 1.0, but Triton only uses API 2.0, so the build is not included to save image size.
- The `3rdparty` directory no longer exists after the build.
- There are quite a few extra libraries built but not used by the OpenVINO backend (i.e. PaddlePaddle), so only the required libraries are included to save final image size.
- The `tbb.dll`s on Windows have changed, so the dockerfile is updated to reflect the change.