### PR TITLE
Revert "Add support for models with dynamic shapes (#69)"

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,9 +137,7 @@ and
 is provided, then `dynamic_batching` will be enabled with default settings.
 
 
-## Examples of the "config.pbtxt" file sections depending on the use case
-
-### Latency mode
+### Examples of the "config.pbtxt" files depending on the use case
 
 Latency mode with low concurrency on the client side. Recommended for performance optimization with low number of parallel clients.
 ```
@@ -158,8 +156,6 @@ parameters: [
 }
 ]
 ```
-
-### Throughput mode
 
 Throughput mode with high concurrency on the client side. Recommended for throughput optimization with high number of parallel clients.
 Number of streams should be lower or equal to number of parallel clients and lower of equal to the number of CPU cores.
@@ -181,14 +177,19 @@ parameters: [
 ]
 ```
 
-### Loading non default model format
-
 When loading model with the non default format of Intermediate Representation and the name model.xml, use and extra parameter "default_model_filename".
 For example, using TensorFlow saved_model format use:
 ```
 default_model_filename: "model.saved_model"
+parameters: [
+{
+   key: "PERFORMANCE_HINT"
+   value: {
+     string_value: "LATENCY"
+   }
+}
+]
 ```
-
 and copy the model to the subfolder called "model.saved_model"
 ```
 model_repository/
@@ -200,38 +201,12 @@ model_repository/
     └── config.pbtxt
 
 ```
-Other allowed values are `model.pdmodel` or `model.onnx`.
-### Reshaping models
 
-Following section shows how to use OpenVINO dynamic shapes. `-1` denotes dimension accepting any value on input. In this case
-while model originally accepted input with layout `NCHW` and shape `(1,3,224,224)`, now it accepts any batch size and resolution.
-
-*Note*: If the model is originally exported with dynamic shapes, there is no need to manually specify dynamic shapes in config.
-
-```
-input [
-  {
-    name: "input"
-    data_type: TYPE_FP32
-    dims: [ -1, 3, -1, -1]
-  }
-]
-output [
-  {
-    name: "output"
-    data_type: TYPE_FP32
-    dims: [ -1, 1001]
-  }
-]
-parameters: {
-key: "RESHAPE_IO_LAYERS"
-value: {
-string_value:"yes"
-}
-}
-```
 
 ## Known Issues
 
+* Models with dynamic shape are not supported in this backend now.
+
+* As of now, the Openvino backend does not support variable shaped tensors. However, the dynamic batch sizes in the model are supported. See `SKIP_OV_DYNAMIC_BATCHSIZE` and `ENABLE_BATCH_PADDING` parameters for more details.
+
 * Models with the scalar on the input (shape without any dimension are not supported)
-* Reshaping using [dimension ranges](https://docs.openvino.ai/2023.3/ovms_docs_dynamic_shape_dynamic_model.html) is not supported.

--- a/src/openvino_utils.cc
+++ b/src/openvino_utils.cc
@@ -195,25 +195,24 @@ OpenVINOElementToModelConfigDataType(const ov::element::Type& data_type)
   return "TYPE_INVALID";
 }
 
-static bool
-doesMatch(const ov::Dimension& ov_dim, int64_t config_dim)
-{
-  if (ov_dim.is_static()) {
-    return ov_dim.get_length() == config_dim;
-  }
-  if (!ov_dim.get_interval().has_upper_bound()) {
-    return true;
-  }
-  return (config_dim < ov_dim.get_max_length()) &&
-         (config_dim > ov_dim.get_min_length());
-}
-
 TRITONSERVER_Error*
 CompareDimsSupported(
     const std::string& model_name, const std::string& tensor_name,
-    const ov::PartialShape& model_shape, const std::vector<int64_t>& dims,
+    const std::vector<size_t>& model_shape, const std::vector<int64_t>& dims,
     const int max_batch_size, const bool compare_exact)
 {
+  // TODO: OpenVINO backend does not support the dynamic shapes as of now.
+  // We can use RESIZE_BILINEAR preProcess in InputInfo to support dynamic
+  // shapes in future.
+  for (const auto& dim : dims) {
+    RETURN_ERROR_IF_TRUE(
+        (dim == -1), TRITONSERVER_ERROR_INVALID_ARG,
+        std::string("model '") + model_name + "', tensor '" + tensor_name +
+            "': provides -1 dim (shape " + ShapeToString(dims) +
+            "), openvino "
+            "currently does not support dynamic shapes.");
+  }
+
   // If the model configuration expects batching support in the model,
   // then the openvino first dimension will be reshaped hence should not
   // be compared.
@@ -233,8 +232,9 @@ CompareDimsSupported(
     bool succ = (model_shape.size() == (size_t)full_dims.size());
     if (succ) {
       for (size_t i = 0; i < full_dims.size(); ++i) {
-        if (compare_exact || ((i != 0) && (full_dims[i] != -1))) {
-          succ &= doesMatch(model_shape[i], full_dims[i]);
+        const int64_t model_dim = model_shape[i];
+        if (compare_exact || (i != 0)) {
+          succ &= (model_dim == full_dims[i]);
         }
       }
     }
@@ -256,7 +256,8 @@ CompareDimsSupported(
     bool succ = (model_shape.size() == dims.size());
     if (succ) {
       for (size_t i = 0; i < dims.size(); ++i) {
-        succ &= doesMatch(model_shape[i], dims[i]);
+        const int64_t model_dim = model_shape[i];
+        succ &= (model_dim == dims[i]);
       }
     }
 
@@ -288,13 +289,9 @@ ReadParameter(
 }
 
 std::vector<int64_t>
-ConvertToSignedShape(const ov::PartialShape& shape)
+ConvertToSignedShape(const std::vector<size_t> shape)
 {
-  std::vector<int64_t> out;
-  for (const auto& dim : shape) {
-    out.emplace_back(dim.is_static() ? dim.get_length() : -1);
-  }
-  return out;
+  return std::vector<int64_t>{shape.begin(), shape.end()};
 }
 
 }}}  // namespace triton::backend::openvino

--- a/src/openvino_utils.h
+++ b/src/openvino_utils.h
@@ -92,13 +92,13 @@ std::string OpenVINOElementToModelConfigDataType(
 
 TRITONSERVER_Error* CompareDimsSupported(
     const std::string& model_name, const std::string& tensor_name,
-    const ov::PartialShape& model_shape, const std::vector<int64_t>& dims,
+    const std::vector<size_t>& model_shape, const std::vector<int64_t>& dims,
     const int max_batch_size, const bool compare_exact);
 
 TRITONSERVER_Error* ReadParameter(
     triton::common::TritonJson::Value& params, const std::string& key,
     std::string* param);
 
-std::vector<int64_t> ConvertToSignedShape(const ov::PartialShape& shape);
+std::vector<int64_t> ConvertToSignedShape(const std::vector<size_t> shape);
 
 }}}  // namespace triton::backend::openvino


### PR DESCRIPTION
This reverts commit a68ca46bc88a324982a0f35e9785d92a283466bf.

The commit we are reverting breaks our build with the following error:
```
/tmp/tritonbuild/openvino/src/openvino.cc: In member function 'TRITONSERVER_Error* triton::backend::openvino::ModelState::ValidateInputs(size_t)':
/tmp/tritonbuild/openvino/src/openvino.cc:572:20: error: cannot convert 'std::string' {aka 'std::__cxx11::basic_string<char>'} to 'const char*'
  572 |               std::string("openvino backend does dimensions values other than "
      |                    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
      |                    |
      |                    std::string {aka std::__cxx11::basic_string<char>}
  573 |                           "-1 or positive integers"));
      |                           ~~~~~~~~~~~~~~~~~~~~~~~~~~
In file included from /tmp/tritonbuild/openvino/build/_deps/repo-core-src/include/triton/core/tritonbackend.h:31,
                 from /tmp/tritonbuild/openvino/build/_deps/repo-backend-src/include/triton/backend/backend_common.h:39,
                 from /tmp/tritonbuild/openvino/src/openvino_utils.h:35,
                 from /tmp/tritonbuild/openvino/src/openvino.cc:33:
/tmp/tritonbuild/openvino/build/_deps/repo-core-src/include/triton/core/tritonserver.h:324:47: note:   initializing argument 2 of 'TRITONSERVER_Error* TRITONSERVER_ErrorNew(TRITONSERVER_Error_Code, const char*)'
  324 |     TRITONSERVER_Error_Code code, const char* msg);
      |                                   ~~~~~~~~~~~~^~~
```