### PR TITLE
Dynamic shapes build 24.02 (#72)

### DIFF
--- a/src/openvino.cc
+++ b/src/openvino.cc
@@ -554,24 +554,32 @@ ModelState::ValidateInputs(const size_t expected_input_cnt)
     }
 
     ov::Shape input_shape;
+    ov::PartialShape partial_input_shape;
     RETURN_IF_OPENVINO_ASSIGN_ERROR(
-        input_shape,
-        model_inputs[model_inputs_name_to_index[io_name]].get_shape(),
+        partial_input_shape,
+        model_inputs[model_inputs_name_to_index[io_name]].get_partial_shape(),
         ("retrieving original shapes from input " + io_name).c_str());
-
     if (reshape_io_layers_) {
       int index = (MaxBatchSize() != 0) ? 1 : 0;
       for (const auto dim : dims) {
-        input_shape[index++] = dim;
+        if (dim > 0) {
+          partial_input_shape[index++] = ov::Dimension(dim);
+        } else if (dim == -1) {
+          partial_input_shape[index++] = ov::Dimension::dynamic();
+        } else {
+          return TRITONSERVER_ErrorNew(
+              TRITONSERVER_ERROR_INTERNAL,
+              "openvino backend does not support dimensions values"
+              " other than `-1` or positive integers");
+        }
       }
       RETURN_IF_OPENVINO_ERROR(
-          ppp.input(io_name).tensor().set_shape(input_shape),
+          ppp.input(io_name).tensor().set_shape(partial_input_shape),
           std::string("setting shape for " + io_name).c_str());
     } else {
       RETURN_IF_ERROR(CompareDimsSupported(
-          Name(), io_name,
-          std::vector<size_t>(input_shape.begin(), input_shape.end()), dims,
-          MaxBatchSize(), false /* compare_exact */));
+          Name(), io_name, partial_input_shape, dims, MaxBatchSize(),
+          false /* compare_exact */));
     }
 
     if (MaxBatchSize()) {
@@ -645,15 +653,14 @@ ModelState::ValidateOutputs()
     } else {
       RETURN_IF_ERROR(ParseShape(io, "dims", &dims));
     }
-    ov::Shape output_shape;
+    ov::PartialShape output_shape;
     RETURN_IF_OPENVINO_ASSIGN_ERROR(
         output_shape,
-        model_outputs[model_outputs_name_to_index[io_name]].get_shape(),
+        model_outputs[model_outputs_name_to_index[io_name]].get_partial_shape(),
         ("retrieving original shapes from output " + io_name).c_str());
     RETURN_IF_ERROR(CompareDimsSupported(
-        Name(), io_name,
-        std::vector<size_t>(output_shape.begin(), output_shape.end()), dims,
-        MaxBatchSize(), true /* compare_exact */));
+        Name(), io_name, output_shape, dims, MaxBatchSize(),
+        true /* compare_exact */));
   }
 
   // Model preprocessing
@@ -812,9 +819,9 @@ ModelState::AutoCompleteInputOrOutput(
           "data_type",
           OpenVINOElementToModelConfigDataType(ov_io.get_element_type())));
       // Find shape
-      ov::Shape io_shape;
+      ov::PartialShape io_shape;
       RETURN_IF_OPENVINO_ASSIGN_ERROR(
-          io_shape, ov_io.get_shape(),
+          io_shape, ov_io.get_partial_shape(),
           ("retrieving original shapes from" + std::string(io_json_obj_name) +
            " " + io_name)
               .c_str());
@@ -822,7 +829,8 @@ ModelState::AutoCompleteInputOrOutput(
       triton::common::TritonJson::Value dims(
           ModelConfig(), triton::common::TritonJson::ValueType::ARRAY);
       for (size_t i = (MaxBatchSize() > 0) ? 1 : 0; i < io_shape.size(); i++) {
-        RETURN_IF_ERROR(dims.AppendInt(io_shape[i]));
+        RETURN_IF_ERROR(dims.AppendInt(
+            io_shape.is_static() ? io_shape[i].get_length() : -1));
       }
       RETURN_IF_ERROR(io_json.Add("dims", std::move(dims)));
       // Add individual input/output to new input/output
@@ -842,7 +850,6 @@ ModelState::AutoCompleteInputOrOutput(
          "': " + io_json_obj_name + " already specified")
             .c_str());
   }
-
   return nullptr;  // success
 }
 
@@ -931,7 +938,7 @@ ModelInstanceState::ModelInstanceState(
     throw triton::backend::BackendModelInstanceException(TRITONSERVER_ErrorNew(
         TRITONSERVER_ERROR_INVALID_ARG,
         (std::string("unable to load model '") + model_state_->Name() +
-         "', openVINO backend supports only CPU device")
+         "', Triton openVINO backend supports only CPU device")
             .c_str()));
   }
 
@@ -1363,7 +1370,6 @@ TRITONBACKEND_Initialize(TRITONBACKEND_Backend* backend)
   const char* cname;
   RETURN_IF_ERROR(TRITONBACKEND_BackendName(backend, &cname));
   std::string name(cname);
-
   LOG_MESSAGE(
       TRITONSERVER_LOG_INFO,
       (std::string("TRITONBACKEND_Initialize: ") + name).c_str());

--- a/src/openvino_utils.h
+++ b/src/openvino_utils.h
@@ -92,13 +92,13 @@ std::string OpenVINOElementToModelConfigDataType(
 
 TRITONSERVER_Error* CompareDimsSupported(
     const std::string& model_name, const std::string& tensor_name,
-    const std::vector<size_t>& model_shape, const std::vector<int64_t>& dims,
+    const ov::PartialShape& model_shape, const std::vector<int64_t>& dims,
     const int max_batch_size, const bool compare_exact);
 
 TRITONSERVER_Error* ReadParameter(
     triton::common::TritonJson::Value& params, const std::string& key,
     std::string* param);
 
-std::vector<int64_t> ConvertToSignedShape(const std::vector<size_t> shape);
+std::vector<int64_t> ConvertToSignedShape(const ov::PartialShape& shape);
 
 }}}  // namespace triton::backend::openvino


### PR DESCRIPTION
This PR cherry-picks the following commit into the r24.03 release: https://github.com/triton-inference-server/openvino_backend/pull/72. This PR has been verified in our private CI.

* Revert "Revert "Add support for models with dynamic shapes (#69)" (#70)"

This reverts commit 25934f615ca905b9586b5fa781f4b78129e94f4b.

* Fix building after style fixes