### PR TITLE
Create CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -6,4 +6,4 @@
 # These owners will be the default owners for everything in
 # the repo. These owners will be requested for
 # review when someone opens a pull request.
-*       @triton-inference-server/openvino-maintainers
+*       @nnshah1 @dtrawins

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -6,4 +6,4 @@
 # These owners will be the default owners for everything in
 # the repo. These owners will be requested for
 # review when someone opens a pull request.
-*       @triton-inference-server/openvino-maintainers @dtrawins
+*       @triton-inference-server/openvino-maintainers @dtrawins @atobiszei

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,9 @@
+##############################################################
+# List of approvers/reviewers for openvino backend repository
+##############################################################
+# Learn about CODEOWNERS file format:
+#  https://help.github.com/en/articles/about-code-owners
+# These owners will be the default owners for everything in
+# the repo. These owners will be requested for
+# review when someone opens a pull request.
+*       @triton-inference-server/required-code-reviewers

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -6,4 +6,4 @@
 # These owners will be the default owners for everything in
 # the repo. These owners will be requested for
 # review when someone opens a pull request.
-*       @triton-inference-server/required-code-reviewers
+*       @triton-inference-server/openvino-maintainers

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -6,4 +6,4 @@
 # These owners will be the default owners for everything in
 # the repo. These owners will be requested for
 # review when someone opens a pull request.
-*       @nnshah1 @dtrawins
+*       @triton-inference-server/openvino-maintainers @dtrawins


### PR DESCRIPTION
Code owners are automatically requested for review when someone opens a pull request that modifies code that they own. Code owners are not automatically requested to review draft pull requests.

I have updated settings of this repository to require Approval for PRs from the code-reviewers team.
The team is mentioned here and defined here: https://github.com/orgs/triton-inference-server/teams/required-code-reviewers 
Please feel free to add more code reviewers to this team.