### PR TITLE
add support for TARGET_DEVICE parameter

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -210,7 +210,6 @@ else()
     COMMAND rm -fr openvino
     COMMAND docker cp openvino_backend_ov:/opt/openvino openvino
     COMMAND docker rm openvino_backend_ov
-    COMMAND echo '<ie><plugins><plugin name=\"CPU\" location=\"libopenvino_intel_cpu_plugin.so\"></plugin></plugins></ie>' >> openvino/lib/plugins.xml
     COMMENT "Building OpenVino"
   )
 endif() # WIN32

--- a/Dockerfile.drivers
+++ b/Dockerfile.drivers
@@ -1,0 +1,16 @@
+ARG BASE_OS=tritonserver:latest
+FROM $BASE_OS
+RUN mkdir /tmp/neo && cd /tmp/neo && \
+    apt-get update && apt-get install -y libtbb12 curl && \
+    curl -L -O https://github.com/intel/intel-graphics-compiler/releases/download/igc-1.0.17791.9/intel-igc-core_1.0.17791.9_amd64.deb && \
+    curl -L -O https://github.com/intel/intel-graphics-compiler/releases/download/igc-1.0.17791.9/intel-igc-opencl_1.0.17791.9_amd64.deb && \
+    curl -L -O https://github.com/intel/compute-runtime/releases/download/24.39.31294.12/intel-level-zero-gpu_1.6.31294.12_amd64.deb && \
+    curl -L -O https://github.com/intel/compute-runtime/releases/download/24.39.31294.12/intel-opencl-icd_24.39.31294.12_amd64.deb && \
+    curl -L -O https://github.com/intel/compute-runtime/releases/download/24.39.31294.12/libigdgmm12_22.5.2_amd64.deb && \
+    curl -L -O https://github.com/oneapi-src/level-zero/releases/download/v1.17.44/level-zero_1.17.44+u24.04_amd64.deb && \
+    curl -L -O https://github.com/intel/linux-npu-driver/releases/download/v1.10.0/intel-driver-compiler-npu_1.10.0.20241107-11729849322_ubuntu24.04_amd64.deb && \
+    curl -L -O https://github.com/intel/linux-npu-driver/releases/download/v1.10.0/intel-fw-npu_1.10.0.20241107-11729849322_ubuntu24.04_amd64.deb && \
+    curl -L -O https://github.com/intel/linux-npu-driver/releases/download/v1.10.0/intel-level-zero-npu_1.10.0.20241107-11729849322_ubuntu24.04_amd64.deb && \
+    dpkg -i *.deb && \
+    apt-get install -y ocl-icd-libopencl1 && \
+    rm -Rf /tmp/neo

--- a/README.md
+++ b/README.md
@@ -269,7 +269,7 @@ parameters: [
 
 Start the container with extra parameter to pass the device `/dev/dri`:
 ```
-docker run -it --rm --device /dev/dri --group-add=$(stat -c "%g" /dev/dri/render* )  tritonserver:latest 
+docker run -it --rm --device /dev/dri --group-add=$(stat -c "%g" /dev/dri/render* )  tritonserver:latest
 ```
 
 ## Known Issues

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ Follow the steps below to build the backend shared library.
 ```
 $ mkdir build
 $ cd build
-$ cmake -DCMAKE_INSTALL_PREFIX:PATH=`pwd`/install -DTRITON_BUILD_OPENVINO_VERSION=2024.0.0 -DTRITON_BUILD_CONTAINER_VERSION=24.02 ..
+$ cmake -DCMAKE_INSTALL_PREFIX:PATH=`pwd`/install -DTRITON_BUILD_OPENVINO_VERSION=2021.2.200 -DTRITON_BUILD_CONTAINER_VERSION=20.12 ..
 $ make install
 ```
 
@@ -72,8 +72,11 @@ but the listed CMake argument can be used to override.
 * triton-inference-server/common: -DTRITON_COMMON_REPO_TAG=[tag]
 
 ## Build a complete image with OpenVINO backend including Intel GPU drivers
+
+Build the custom triton image with the required runtime drivers using the script from [build.py](https://github.com/dtrawins/server/blob/igpu/build.py).
+
 ```
-python3 build.py --target-platform linux --enable-logging --enable-stats --enable-metrics --enable-cpu-metrics \
+python3 build.py --target-platform linux --enable-logging --enable-stats --enable-metrics --enable-cpu-metrics --endpoint grpc --endpoint http --filesystem s3 \
 --backend openvino:pull/74/head --enable-intel-gpu
 ```
 
@@ -240,11 +243,6 @@ string_value:"yes"
 ```
 ### Running the models on Intel GPU
 
-Build the custom triton image with the required runtime drivers using the script from [build.py](https://github.com/dtrawins/server/blob/igpu/build.py).
-
-```
-python3 build.py --target-platform linux --enable-logging --enable-stats --enable-metrics --enable-cpu-metrics --endpoint grpc --endpoint http --filesystem s3
-```
 Add to your config.pbtxt a parameter `TARGET_DEVICE`:
 ```
 parameters: [

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ Follow the steps below to build the backend shared library.
 ```
 $ mkdir build
 $ cd build
-$ cmake -DCMAKE_INSTALL_PREFIX:PATH=`pwd`/install -DTRITON_BUILD_OPENVINO_VERSION=2021.2.200 -DTRITON_BUILD_CONTAINER_VERSION=20.12 ..
+$ cmake -DCMAKE_INSTALL_PREFIX:PATH=`pwd`/install -DTRITON_BUILD_OPENVINO_VERSION=2024.0.0 -DTRITON_BUILD_CONTAINER_VERSION=24.02 ..
 $ make install
 ```
 
@@ -70,6 +70,8 @@ but the listed CMake argument can be used to override.
 * triton-inference-server/backend: -DTRITON_BACKEND_REPO_TAG=[tag]
 * triton-inference-server/core: -DTRITON_CORE_REPO_TAG=[tag]
 * triton-inference-server/common: -DTRITON_COMMON_REPO_TAG=[tag]
+
+
 
 ## Using the OpenVINO Backend
 

--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ Build the custom triton image with the required runtime drivers using the script
 
 ```
 python3 build.py --target-platform linux --enable-logging --enable-stats --enable-metrics --enable-cpu-metrics --endpoint grpc --endpoint http --filesystem s3 \
---backend openvino:pull/74/head --enable-intel-gpu
+--backend openvino
 ```
 
 

--- a/README.md
+++ b/README.md
@@ -240,7 +240,7 @@ string_value:"yes"
 ```
 ### Running the models on Intel GPU
 
-Build the custom triton image with the required runtime drivers using the script from .
+Build the custom triton image with the required runtime drivers using the script from [build.py](https://github.com/dtrawins/server/blob/igpu/build.py).
 
 ```
 python3 build.py --target-platform linux --enable-logging --enable-stats --enable-metrics --enable-cpu-metrics --endpoint grpc --endpoint http --filesystem s3

--- a/README.md
+++ b/README.md
@@ -243,7 +243,7 @@ string_value:"yes"
 Build the custom triton image with the required runtime drivers using the script from .
 
 ```
-python3 build.py --target-platform linux --enable-logging --enable-stats --enable-metrics --enable-cpu-metrics
+python3 build.py --target-platform linux --enable-logging --enable-stats --enable-metrics --enable-cpu-metrics --endpoint grpc --endpoint http --filesystem s3
 ```
 Add to your config.pbtxt a parameter `TARGET_DEVICE`:
 ```

--- a/src/openvino.cc
+++ b/src/openvino.cc
@@ -121,7 +121,7 @@ class ModelState : public BackendModel {
 
   bool SkipDynamicBatchSize() { return skip_dynamic_batchsize_; }
   bool EnableBatchPadding() { return enable_padding_; }
-  std::string TargetDevice() {return target_device_;}
+  std::string TargetDevice() { return target_device_; }
 
  private:
   ModelState(TRITONBACKEND_Model* triton_model);
@@ -243,7 +243,8 @@ ModelState::ParseParameters()
   bool status = model_config_.Find("parameters", &params);
   if (status) {
     RETURN_IF_ERROR(LoadCpuExtensions(params));
-    ParseBoolParameter("SKIP_OV_DYNAMIC_BATCHSIZE", params, &skip_dynamic_batchsize_);
+    ParseBoolParameter(
+        "SKIP_OV_DYNAMIC_BATCHSIZE", params, &skip_dynamic_batchsize_);
     ParseBoolParameter("ENABLE_BATCH_PADDING", params, &enable_padding_);
     ParseBoolParameter("RESHAPE_IO_LAYERS", params, &reshape_io_layers_);
     ParseStringParameter("TARGET_DEVICE", params, &target_device_);
@@ -297,8 +298,7 @@ ModelState::ParseBoolParameter(
     bool* setting)
 {
   std::string value;
-  RETURN_IF_ERROR(
-      ReadParameter(params, mkey, &(value)));
+  RETURN_IF_ERROR(ReadParameter(params, mkey, &(value)));
   std::transform(
       value.begin(), value.end(), value.begin(),
       [](unsigned char c) { return std::tolower(c); });
@@ -315,8 +315,7 @@ ModelState::ParseStringParameter(
     std::string* setting)
 {
   std::string value;
-  RETURN_IF_ERROR(
-      ReadParameter(params, mkey, &(value)));
+  RETURN_IF_ERROR(ReadParameter(params, mkey, &(value)));
   std::transform(
       value.begin(), value.end(), value.begin(),
       [](unsigned char c) { return std::toupper(c); });
@@ -333,8 +332,7 @@ ModelState::ParseParameter(
     std::vector<std::pair<std::string, ov::Any>>* device_config)
 {
   std::string value;
-  RETURN_IF_ERROR(
-      ReadParameter(params, mkey, &(value)));
+  RETURN_IF_ERROR(ReadParameter(params, mkey, &(value)));
   if (!value.empty()) {
     std::pair<std::string, ov::Any> ov_property;
     RETURN_IF_ERROR(ParseParameterHelper(mkey, &value, &ov_property));
@@ -427,8 +425,8 @@ ModelState::ConfigureOpenvinoCore()
   auto availableDevices = ov_core_.get_available_devices();
   std::stringstream list_of_devices;
 
-  for (auto & element : availableDevices) {
-    list_of_devices << element << ",";  
+  for (auto& element : availableDevices) {
+    list_of_devices << element << ",";
   }
   LOG_MESSAGE(
       TRITONSERVER_LOG_VERBOSE,
@@ -957,9 +955,11 @@ ModelInstanceState::Create(
 ModelInstanceState::ModelInstanceState(
     ModelState* model_state, TRITONBACKEND_ModelInstance* triton_model_instance)
     : BackendModelInstance(model_state, triton_model_instance),
-      model_state_(model_state), device_(model_state->TargetDevice()), batch_pad_size_(0)
+      model_state_(model_state), device_(model_state->TargetDevice()),
+      batch_pad_size_(0)
 {
-  if ((Kind() != TRITONSERVER_INSTANCEGROUPKIND_CPU) && (Kind() != TRITONSERVER_INSTANCEGROUPKIND_AUTO)) {
+  if ((Kind() != TRITONSERVER_INSTANCEGROUPKIND_CPU) &&
+      (Kind() != TRITONSERVER_INSTANCEGROUPKIND_AUTO)) {
     throw triton::backend::BackendModelInstanceException(TRITONSERVER_ErrorNew(
         TRITONSERVER_ERROR_INVALID_ARG,
         (std::string("unable to load model '") + model_state_->Name() +
@@ -972,10 +972,9 @@ ModelInstanceState::ModelInstanceState(
     THROW_IF_BACKEND_INSTANCE_ERROR(model_state_->ParseParameters());
     device_ = model_state->TargetDevice();
     LOG_MESSAGE(
-      TRITONSERVER_LOG_INFO,
-      (std::string("Target device " + device_))
-          .c_str());
-    
+        TRITONSERVER_LOG_INFO,
+        (std::string("Target device " + device_)).c_str());
+
 
     THROW_IF_BACKEND_INSTANCE_ERROR(
         model_state_->ReadModel(ArtifactFilename(), &model_path));
@@ -1550,7 +1549,7 @@ TRITONBACKEND_ModelInstanceInitialize(TRITONBACKEND_ModelInstance* instance)
   LOG_MESSAGE(
       TRITONSERVER_LOG_INFO,
       (std::string("TRITONBACKEND_ModelInstanceInitialize: ") + name + " (" +
-       TRITONSERVER_InstanceGroupKindString(kind)+")")
+       TRITONSERVER_InstanceGroupKindString(kind) + ")")
           .c_str());
 
   // Get the model state associated with this instance's model.

--- a/src/openvino_utils.cc
+++ b/src/openvino_utils.cc
@@ -277,13 +277,14 @@ CompareDimsSupported(
 TRITONSERVER_Error*
 ReadParameter(
     triton::common::TritonJson::Value& params, const std::string& key,
-    std::string* param)
+    std::string* param, const std::string default_value)
 {
   triton::common::TritonJson::Value value;
-  RETURN_ERROR_IF_FALSE(
-      params.Find(key.c_str(), &value), TRITONSERVER_ERROR_INVALID_ARG,
-      std::string("model configuration is missing the parameter ") + key);
-  RETURN_IF_ERROR(value.MemberAsString("string_value", param));
+  if (params.Find(key.c_str(), &value)){
+    RETURN_IF_ERROR(value.MemberAsString("string_value", param));
+  } else {
+    *param = default_value;
+  }
   return nullptr;  // success
 }
 

--- a/src/openvino_utils.h
+++ b/src/openvino_utils.h
@@ -97,7 +97,7 @@ TRITONSERVER_Error* CompareDimsSupported(
 
 TRITONSERVER_Error* ReadParameter(
     triton::common::TritonJson::Value& params, const std::string& key,
-    std::string* param);
+    std::string* param, const std::string default_value);
 
 std::vector<int64_t> ConvertToSignedShape(const ov::PartialShape& shape);
 

--- a/tools/gen_openvino_dockerfile.py
+++ b/tools/gen_openvino_dockerfile.py
@@ -76,15 +76,6 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 # pre-build archive.
 # TODO: Unify build steps between linux and windows.
 
-# Get intel GPU drivers
-WORKDIR /drv
-RUN curl -L -O https://github.com/intel/intel-graphics-compiler/releases/download/igc-1.0.15468.11/intel-igc-core_1.0.15468.11_amd64.deb ; \
-    curl -L -O https://github.com/intel/intel-graphics-compiler/releases/download/igc-1.0.15468.11/intel-igc-opencl_1.0.15468.11_amd64.deb ; \
-    curl -L -O https://github.com/intel/compute-runtime/releases/download/23.43.27642.18/intel-opencl-icd_23.43.27642.18_amd64.deb ; \
-    curl -L -O https://github.com/intel/compute-runtime/releases/download/23.43.27642.18/libigdgmm12_22.3.11_amd64.deb ; \
-    apt-get download ocl-icd-libopencl1 ; \
-    find . -iname '*.deb' -exec  dpkg-deb -X {} . \;
-
 ARG OPENVINO_VERSION
 ARG OPENVINO_BUILD_TYPE
 WORKDIR /workspace
@@ -115,8 +106,7 @@ RUN mkdir -p include && \
     cp -r /workspace/install/runtime/include/* include/.
 RUN mkdir -p lib && \
     cp -P /workspace/install/runtime/lib/intel64/*.so* lib/. && \
-    cp -P /workspace/install/runtime/lib/intel64/libopenvino*.so* lib/. && \
-    find /drv/usr/ -iname '*.so*' -exec cp -P {} lib/. \;
+    cp -P /workspace/install/runtime/lib/intel64/libopenvino*.so* lib/.
 """
 
     df += """

--- a/tools/gen_openvino_dockerfile.py
+++ b/tools/gen_openvino_dockerfile.py
@@ -62,6 +62,7 @@ ENV DEBIAN_FRONTEND=noninteractive
 RUN apt-get update && apt-get install -y --no-install-recommends \
         cmake \
         libglib2.0-dev \
+        libtbb-dev \
         patchelf \
         git \
         make \
@@ -103,10 +104,11 @@ RUN /bin/bash -c 'cmake \
 WORKDIR /opt/openvino
 RUN cp -r /workspace/openvino/licensing LICENSE.openvino
 RUN mkdir -p include && \
-    cp -r /workspace/install/runtime/include/*  include/.
+    cp -r /workspace/install/runtime/include/ngraph include/. && \
+    cp -r /workspace/install/runtime/include/openvino include/.
 RUN mkdir -p lib && \
-    cp -P /workspace/install/runtime/lib/intel64/*.so* lib/. && \
-    cp -P /workspace/install/runtime/3rdparty/tbb/lib/libtbb.so* lib/.
+    cp -P /usr/lib/x86_64-linux-gnu/libtbb.so* lib/. && \
+    cp -P /workspace/install/runtime/lib/intel64/libopenvino*.so* lib/. \
 """
 
     df += """

--- a/tools/gen_openvino_dockerfile.py
+++ b/tools/gen_openvino_dockerfile.py
@@ -77,6 +77,15 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 # pre-build archive.
 # TODO: Unify build steps between linux and windows.
 
+# Get intel GPU drivers
+WORKDIR /drv
+RUN curl -L -O https://github.com/intel/intel-graphics-compiler/releases/download/igc-1.0.15468.11/intel-igc-core_1.0.15468.11_amd64.deb ; \
+    curl -L -O https://github.com/intel/intel-graphics-compiler/releases/download/igc-1.0.15468.11/intel-igc-opencl_1.0.15468.11_amd64.deb ; \
+    curl -L -O https://github.com/intel/compute-runtime/releases/download/23.43.27642.18/intel-opencl-icd_23.43.27642.18_amd64.deb ; \
+    curl -L -O https://github.com/intel/compute-runtime/releases/download/23.43.27642.18/libigdgmm12_22.3.11_amd64.deb ; \
+    apt-get download ocl-icd-libopencl1 ; \
+    find . -iname '*.deb' -exec  dpkg-deb -X {} . \;
+
 ARG OPENVINO_VERSION
 ARG OPENVINO_BUILD_TYPE
 WORKDIR /workspace
@@ -104,11 +113,11 @@ RUN /bin/bash -c 'cmake \
 WORKDIR /opt/openvino
 RUN cp -r /workspace/openvino/licensing LICENSE.openvino
 RUN mkdir -p include && \
-    cp -r /workspace/install/runtime/include/ngraph include/. && \
-    cp -r /workspace/install/runtime/include/openvino include/.
+    cp -r /workspace/install/runtime/include/* include/. 
 RUN mkdir -p lib && \
     cp -P /usr/lib/x86_64-linux-gnu/libtbb.so* lib/. && \
-    cp -P /workspace/install/runtime/lib/intel64/libopenvino*.so* lib/. \
+    cp -P /workspace/install/runtime/lib/intel64/libopenvino*.so* lib/. && \
+    find /drv/usr/ -iname '*.so*' -exec cp -P {} lib/. \; 
 """
 
     df += """

--- a/tools/gen_openvino_dockerfile.py
+++ b/tools/gen_openvino_dockerfile.py
@@ -62,7 +62,6 @@ ENV DEBIAN_FRONTEND=noninteractive
 RUN apt-get update && apt-get install -y --no-install-recommends \
         cmake \
         libglib2.0-dev \
-        libtbb-dev \
         patchelf \
         git \
         make \
@@ -104,11 +103,10 @@ RUN /bin/bash -c 'cmake \
 WORKDIR /opt/openvino
 RUN cp -r /workspace/openvino/licensing LICENSE.openvino
 RUN mkdir -p include && \
-    cp -r /workspace/install/runtime/include/ngraph include/. && \
     cp -r /workspace/install/runtime/include/openvino include/.
 RUN mkdir -p lib && \
-    cp -P /usr/lib/x86_64-linux-gnu/libtbb.so* lib/. && \
-    cp -P /workspace/install/runtime/lib/intel64/libopenvino*.so* lib/. \
+    cp -P /workspace/install/runtime/lib/intel64/*.so* lib/. && \
+    cp -P /workspace/install/runtime/3rdparty/tbb/lib/libtbb.so* /lib/.
 """
 
     df += """

--- a/tools/gen_openvino_dockerfile.py
+++ b/tools/gen_openvino_dockerfile.py
@@ -112,11 +112,11 @@ RUN /bin/bash -c 'cmake \
 WORKDIR /opt/openvino
 RUN cp -r /workspace/openvino/licensing LICENSE.openvino
 RUN mkdir -p include && \
-    cp -r /workspace/install/runtime/include/* include/. 
+    cp -r /workspace/install/runtime/include/* include/.
 RUN mkdir -p lib && \
     cp -P /workspace/install/runtime/lib/intel64/*.so* lib/. && \
     cp -P /workspace/install/runtime/lib/intel64/libopenvino*.so* lib/. && \
-    find /drv/usr/ -iname '*.so*' -exec cp -P {} lib/. \; 
+    find /drv/usr/ -iname '*.so*' -exec cp -P {} lib/. \;
 """
 
     df += """

--- a/tools/gen_openvino_dockerfile.py
+++ b/tools/gen_openvino_dockerfile.py
@@ -103,10 +103,10 @@ RUN /bin/bash -c 'cmake \
 WORKDIR /opt/openvino
 RUN cp -r /workspace/openvino/licensing LICENSE.openvino
 RUN mkdir -p include && \
-    cp -r /workspace/install/runtime/include/openvino include/.
+    cp -r /workspace/install/runtime/include/*  include/.
 RUN mkdir -p lib && \
     cp -P /workspace/install/runtime/lib/intel64/*.so* lib/. && \
-    cp -P /workspace/install/runtime/3rdparty/tbb/lib/libtbb.so* /lib/.
+    cp -P /workspace/install/runtime/3rdparty/tbb/lib/libtbb.so* lib/.
 """
 
     df += """


### PR DESCRIPTION
This is updated version of https://github.com/triton-inference-server/openvino_backend/pull/74 which doesn't require any changed on the base triton image.
It gives option to specify TARGET_DEVICE to be passed to the OpenVINO Runtime during model compilation