### PR TITLE
Update default branch post 25.01

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,8 @@ OpenVINO backend in the public docker image version currently supports inference
 Cmake 3.17 or higher is required. First install the required dependencies.
 
 ```
-$ apt-get install patchelf rapidjson-dev python3-dev
+$ apt-get install rapidjson-dev python3-dev python3-pip
+$ pip3 install patchelf==0.17.2
 ```
 
 Follow the steps below to build the backend shared library.

--- a/tools/gen_openvino_dockerfile.py
+++ b/tools/gen_openvino_dockerfile.py
@@ -58,16 +58,19 @@ def dockerfile_for_linux(output_file):
     df += """
 # Ensure apt-get won't prompt for selecting options
 ENV DEBIAN_FRONTEND=noninteractive
+ENV PIP_BREAK_SYSTEM_PACKAGES=1
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
         cmake \
         libglib2.0-dev \
-        patchelf \
         git \
         make \
         build-essential \
         wget \
-        ca-certificates
+        ca-certificates \
+        python3-pip
+
+RUN pip3 install patchelf==0.17.2
 
 # Build instructions:
 # https://github.com/openvinotoolkit/openvino/wiki/BuildingForLinux


### PR DESCRIPTION
Downgrade patchelf version from 0.18.0 to 0.17.2 due to patchelf regression

Patchelf shipped a regression in 0.18.0 and has since yanked the pypi release pointing to
0.17.2 as the most recent version. However, 0.18.0 is still the version shipped in both the apt and yum
repositories, thus we must use pip to install the version we want.
See https://github.com/mayeut/patchelf-pypi/issues/87
