### PR TITLE
fix: reset batch_pad_size_ at start of ProcessRequests

### DIFF
--- a/src/openvino.cc
+++ b/src/openvino.cc
@@ -1060,6 +1060,11 @@ ModelInstanceState::ProcessRequests(
     }
   }
 
+  // Reset before every call: prevents a stale value from a previous call (or an
+  // earlier loop iteration) from reaching ValidateOutputBatchSize when the
+  // current batch is full and the write branch is skipped.
+  batch_pad_size_ = 0;
+
   for (size_t i = 0; i < request_count; i++) {
     if (max_batch_size > 0) {
       // Retrieve the batch size from one of the inputs, if the model


### PR DESCRIPTION
## Problem

When Triton's dynamic batcher is used with `ENABLE_BATCH_PADDING=YES`, the OpenVINO backend intermittently returns the error `expected batch size of at least N in model output, got M`. The failure is non-deterministic and scales with request concurrency.

## Root cause

`batch_pad_size_` is a member variable of `ModelInstanceState`. Inside `ProcessRequests()` it is written only inside an `if (total_batch_size != max_batch_size)` block — there is no `else { batch_pad_size_ = 0; }`. The value therefore persists across calls and across loop iterations within a single call.

When the current batch is exactly `max_batch_size`, the branch is skipped and any stale value from a previous call propagates into `ValidateOutputBatchSize`, which trims the output tensor to `max_batch_size − stale_pad`. Triton rejects the mismatched shape:

```
failed to split the output tensor 'output' in responses:
expected batch size of at least 8 in model output, got 7
```

The bug is only reachable when `ENABLE_BATCH_PADDING=YES` (the path that writes `batch_pad_size_` is dead otherwise).

## Fix

One line, immediately before the request-accumulation loop:

```diff
--- a/src/openvino.cc
+++ b/src/openvino.cc
@@ -1061,6 +1061,11 @@ ModelInstanceState::ProcessRequests(
   }
 
+  // Reset before every call: prevents a stale value from a previous call (or
+  // an earlier loop iteration) from reaching ValidateOutputBatchSize when the
+  // current batch is full and the write branch is skipped.
+  batch_pad_size_ = 0;
+
   for (size_t i = 0; i < request_count; i++) {
     if (max_batch_size > 0) {
       // Retrieve the batch size from one of the inputs, if the model
```

After the reset the loop may still write the correct padding for the current call. This is a no-op for all configurations that do not use `ENABLE_BATCH_PADDING`, where `batch_pad_size_` is always `0`.

## Reproduction

Requires Docker with `linux/amd64` support.

Generate a minimal ONNX model (`[N,4] → Mul(×2) → [N,4]`) with `max_batch_size: 8` and `ENABLE_BATCH_PADDING: YES`. Start the stock unpatched image:

```bash
docker run --rm --platform linux/amd64 \
    -p 8000:8000 -v "$PWD/model_repo:/models:ro" \
    nvcr.io/nvidia/tritonserver:26.03-py3 \
    tritonserver --model-repository=/models
```

Alternate requests between `bs=7` (sets `batch_pad_size_ = 1`) and `bs=8` (exact-max, branch skipped, stale pad remains). Every `bs=8` request fails:

```
expected batch size of at least 8 in model output, got 7
```

With the patch applied, all requests succeed.
