### PR TITLE
build: update OpenVINO Dockerfile generation for latest upstream build

### DIFF
--- a/tools/gen_openvino_dockerfile.py
+++ b/tools/gen_openvino_dockerfile.py
@@ -123,8 +123,8 @@ RUN cp -r /workspace/openvino/licensing LICENSE.openvino
 RUN mkdir -p include && \\
     cp -r /workspace/install/runtime/include/* include/.
 RUN mkdir -p lib && \\
-    find /workspace/install/runtime/3rdparty/tbb/lib/ -type f -name "libtbb.so*" -exec cp -v {} lib/ \\; && \\
-    find /workspace/install/runtime/lib/ -type f -name "libopenvino*.so*" -exec cp -v {} lib/ \\;
+    find /workspace/install/runtime/3rdparty/tbb/lib/ -name "libtbb.so*" -exec cp -v {} lib/ \\; && \\
+    find /workspace/install/runtime/lib/ -name "libopenvino*.so*" -exec cp -v {} lib/ \\;
 """
 
     df += """

--- a/tools/gen_openvino_dockerfile.py
+++ b/tools/gen_openvino_dockerfile.py
@@ -76,14 +76,14 @@ RUN apt-get update \\
 ENV DEBIAN_FRONTEND=noninteractive
 ENV PIP_BREAK_SYSTEM_PACKAGES=1
 
-RUN apt-get update && apt-get install -y --no-install-recommends \
-        cmake \
-        libglib2.0-dev \
-        git \
-        make \
-        build-essential \
-        wget \
-        ca-certificates \
+RUN apt-get update && apt-get install -y --no-install-recommends \\
+        cmake \\
+        libglib2.0-dev \\
+        git \\
+        make \\
+        build-essential \\
+        wget \\
+        ca-certificates \\
         python3-pip
 
 RUN pip3 install patchelf==0.17.2
@@ -111,27 +111,27 @@ WORKDIR /workspace/openvino
 RUN git submodule update --init --recursive
 
 WORKDIR /workspace/openvino/build
-RUN /bin/bash -c 'cmake \
-        -DCMAKE_BUILD_TYPE=${OPENVINO_BUILD_TYPE} \
-        -DCMAKE_INSTALL_PREFIX=/workspace/install \
-        -DENABLE_TESTS=OFF \
-        -DENABLE_VALIDATION_SET=OFF \
-        .. && \
+RUN /bin/bash -c 'cmake \\
+        -DCMAKE_BUILD_TYPE=${OPENVINO_BUILD_TYPE} \\
+        -DCMAKE_INSTALL_PREFIX=/workspace/install \\
+        -DENABLE_TESTS=OFF \\
+        -DENABLE_VALIDATION_SET=OFF \\
+        .. && \\
     make -j$(nproc) install'
 
 WORKDIR /opt/openvino
 RUN cp -r /workspace/openvino/licensing LICENSE.openvino
-RUN mkdir -p include && \
+RUN mkdir -p include && \\
     cp -r /workspace/install/runtime/include/* include/.
-RUN mkdir -p lib && \
-    cp -P /workspace/install/runtime/3rdparty/tbb/lib/libtbb.so* lib/. && \
+RUN mkdir -p lib && \\
+    cp -P /workspace/install/runtime/3rdparty/tbb/lib/libtbb.so* lib/. && \\
     cp -P /workspace/install/runtime/lib/intel64/libopenvino*.so* lib/.
 """
 
     df += """
-RUN (cd lib && \
-     for i in `find . -mindepth 1 -maxdepth 1 -type f -name '*\.so*'`; do \
-        patchelf --set-rpath '$ORIGIN' $i; \
+RUN (cd lib && \\
+     for i in $(find . -mindepth 1 -maxdepth 1 -type f -name "*.so*"); do \\
+        patchelf --set-rpath '$ORIGIN' $i; \\
      done)
 """
 

--- a/tools/gen_openvino_dockerfile.py
+++ b/tools/gen_openvino_dockerfile.py
@@ -105,10 +105,9 @@ WORKDIR /workspace
 # are relying on the use of a release branch that does not change once
 # it is released (if a patch is needed for that release we expect
 # there to be a new version).
-RUN git clone -b ${OPENVINO_VERSION} https://github.com/openvinotoolkit/openvino.git
+RUN git clone --recurse-submodules -b ${OPENVINO_VERSION} https://github.com/openvinotoolkit/openvino.git
 
 WORKDIR /workspace/openvino
-RUN git submodule update --init --recursive
 
 RUN cmake \\
         -DCMAKE_BUILD_TYPE=${OPENVINO_BUILD_TYPE} \\

--- a/tools/gen_openvino_dockerfile.py
+++ b/tools/gen_openvino_dockerfile.py
@@ -110,14 +110,15 @@ RUN git clone -b ${OPENVINO_VERSION} https://github.com/openvinotoolkit/openvino
 WORKDIR /workspace/openvino
 RUN git submodule update --init --recursive
 
-WORKDIR /workspace/openvino/build
-RUN /bin/bash -c 'cmake \\
+RUN cmake \\
         -DCMAKE_BUILD_TYPE=${OPENVINO_BUILD_TYPE} \\
         -DCMAKE_INSTALL_PREFIX=/workspace/install \\
         -DENABLE_TESTS=OFF \\
         -DENABLE_VALIDATION_SET=OFF \\
-        .. && \\
-    make -j$(nproc) install'
+        -S /workspace/openvino \\
+        -B /workspace/openvino/build
+
+RUN cmake --build /workspace/openvino/build -j$(nproc) -t install
 
 WORKDIR /opt/openvino
 RUN cp -r /workspace/openvino/licensing LICENSE.openvino

--- a/tools/gen_openvino_dockerfile.py
+++ b/tools/gen_openvino_dockerfile.py
@@ -123,8 +123,8 @@ RUN cp -r /workspace/openvino/licensing LICENSE.openvino
 RUN mkdir -p include && \\
     cp -r /workspace/install/runtime/include/* include/.
 RUN mkdir -p lib && \\
-    find /workspace/install/runtime/3rdparty/tbb/lib/ -type f -name "libtbb.so*" -exec cp -v {} lib/. \\;. && \\
-    find /workspace/install/runtime/lib/ -type f -name "libopenvino*.so*" -exec cp -v {} lib/. \\;.
+    find /workspace/install/runtime/3rdparty/tbb/lib/ -type f -name "libtbb.so*" -exec cp -v {} lib/ \\; && \\
+    find /workspace/install/runtime/lib/ -type f -name "libopenvino*.so*" -exec cp -v {} lib/ \\;
 """
 
     df += """

--- a/tools/gen_openvino_dockerfile.py
+++ b/tools/gen_openvino_dockerfile.py
@@ -77,16 +77,15 @@ ENV DEBIAN_FRONTEND=noninteractive
 ENV PIP_BREAK_SYSTEM_PACKAGES=1
 
 RUN apt-get update && apt-get install -y --no-install-recommends \\
-        cmake \\
-        libglib2.0-dev \\
-        git \\
-        make \\
         build-essential \\
-        wget \\
         ca-certificates \\
-        python3-pip
+        cmake \\
+        git \\
+        libglib2.0-dev \\
+        python3-pip \\
+        wget
 
-RUN pip3 install patchelf==0.17.2
+RUN pip3 install patchelf==0.17.2 scons
 
 # Build instructions:
 # https://github.com/openvinotoolkit/openvino/wiki/BuildingForLinux

--- a/tools/gen_openvino_dockerfile.py
+++ b/tools/gen_openvino_dockerfile.py
@@ -123,8 +123,8 @@ RUN cp -r /workspace/openvino/licensing LICENSE.openvino
 RUN mkdir -p include && \\
     cp -r /workspace/install/runtime/include/* include/.
 RUN mkdir -p lib && \\
-    cp -P /workspace/install/runtime/3rdparty/tbb/lib/libtbb.so* lib/. && \\
-    cp -P /workspace/install/runtime/lib/intel64/libopenvino*.so* lib/.
+    find /workspace/install/runtime/3rdparty/tbb/lib/ -type f -name "libtbb.so*" -exec cp -v {} lib/. \\;. && \\
+    find /workspace/install/runtime/lib/ -type f -name "libopenvino*.so*" -exec cp -v {} lib/. \\;.
 """
 
     df += """


### PR DESCRIPTION
#### What does the PR do?
Updates `tools/gen_openvino_dockerfile.py` so the generated OpenVINO build Dockerfile works against the latest upstream base container:
- Clone OpenVINO with `--recurse-submodules` instead of a separate `git submodule update` step.
- Install `scons`, now required by the OpenVINO build.
- Switch to an out-of-source `cmake -S/-B` configure plus `cmake --build ... -t install`.
- Copy runtime and TBB libraries via `find ... -exec cp` so newer, versioned `.so` names are picked up reliably.
- Normalize shell escaping in the generated Dockerfile.

#### Checklist
- [x] PR title reflects the change and is of format `<commit_type>: <Title>`
- [x] Changes are described in the pull request.
- [x] Related issues are referenced.
- [ ] Populated github labels field
- [ ] Added test plan and verified test passes.
- [ ] Verified that the PR passes existing CI.
- [x] Verified copyright is correct on all changed files.
- [ ] Added succinct git squash message before merging.
- [x] All template sections are filled out.
- [ ] Optional: Additional screenshots for behavior/output changes with before/after.

#### Commit Type:
- [x] build

#### Related PRs:
<!-- No related PRs in other GitHub repositories. -->

#### Where should the reviewer start?
`tools/gen_openvino_dockerfile.py`

#### Test plan:
Build the OpenVINO backend against the latest (26.07) upstream container through the tritonserver CI pipeline.

- CI Pipeline ID: 56763467

#### Caveats:
Depends on the corresponding tritonserver CI changes that switch the upstream base container to 26.07.

#### Background
Part of the pre-code-freeze effort to build Triton against the latest upstream container.

#### Related Issues:
- Resolves: TRI-1534

<sup>
CI (internal): [#56763467](http://tritonserver.local/ci/pipelines/56763467)<br/>
</sup>
